### PR TITLE
允许Bean注解采用函数名

### DIFF
--- a/solon/src/main/java/org/noear/solon/core/AppContext.java
+++ b/solon/src/main/java/org/noear/solon/core/AppContext.java
@@ -836,7 +836,8 @@ public class AppContext extends BeanContainer {
                 m_bw = new BeanWrap(this, beanClz, raw, null, false, anno.initMethod(), anno.destroyMethod());
             }
 
-            String beanName = Utils.annoAlias(anno.value(), anno.name());
+            //允许@Bean注解采用函数名，即支持匿名@Bean
+            String beanName = Utils.valueOr(anno.value(), anno.name(), mWrap.getName());
 
             m_bw.nameSet(beanName);
             m_bw.tagSet(anno.tag());


### PR DESCRIPTION
目前@Bean注解，必须显式指定name或value作为bean名。
优化后，允许默认方式下，采用函数名，即简化@Bean注解