### PR TITLE
新增Chronicle-Bytes 序列化框架

### DIFF
--- a/solon-parent/pom.xml
+++ b/solon-parent/pom.xml
@@ -101,6 +101,7 @@
         <protostuff.version>1.8.0</protostuff.version>
         <kryo.version>5.6.0</kryo.version>
         <sbe.version>1.31.1</sbe.version>
+        <chronicle-bytes.version>2.27ea0</chronicle-bytes.version>
 
         <junit4.version>4.13.2</junit4.version>
         <junit5.version>5.11.0</junit5.version>

--- a/solon-projects/solon-serialization/solon-serialization-abc/pom.xml
+++ b/solon-projects/solon-serialization/solon-serialization-abc/pom.xml
@@ -27,6 +27,13 @@
         </dependency>
 
         <dependency>
+            <groupId>net.openhft</groupId>
+            <artifactId>chronicle-bytes</artifactId>
+            <version>${chronicle-bytes.version}</version>
+        </dependency>
+
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/solon-projects/solon-serialization/solon-serialization-abc/src/main/java/org/noear/solon/serialization/abc/chronicle/bytes/ChrBytesFactory.java
+++ b/solon-projects/solon-serialization/solon-serialization-abc/src/main/java/org/noear/solon/serialization/abc/chronicle/bytes/ChrBytesFactory.java
@@ -1,0 +1,26 @@
+package org.noear.solon.serialization.abc.chronicle.bytes;
+
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.bytes.BytesIn;
+import net.openhft.chronicle.bytes.BytesOut;
+import org.noear.solon.serialization.abc.io.AbcFactory;
+
+public class ChrBytesFactory implements AbcFactory<ChrBytesInput, ChrBytesOutput> {
+    public static final ChrBytesFactory instance = new ChrBytesFactory();
+
+    public static AbcFactory<ChrBytesInput, ChrBytesOutput> getInstance() {
+        return instance;
+    }
+
+    @Override
+    public ChrBytesInput createInput(byte[] bytes) {
+        BytesIn<byte[]> bytesIn = Bytes.wrapForRead(bytes);
+        return new ChrBytesInput(bytesIn);
+    }
+
+    @Override
+    public ChrBytesOutput createOutput() {
+        BytesOut<Void> bytesOut =  Bytes.allocateElasticDirect(128);
+        return new ChrBytesOutput(bytesOut);
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-abc/src/main/java/org/noear/solon/serialization/abc/chronicle/bytes/ChrBytesInput.java
+++ b/solon-projects/solon-serialization/solon-serialization-abc/src/main/java/org/noear/solon/serialization/abc/chronicle/bytes/ChrBytesInput.java
@@ -1,0 +1,12 @@
+package org.noear.solon.serialization.abc.chronicle.bytes;
+
+import org.noear.solon.serialization.abc.io.AbcInput;
+import net.openhft.chronicle.bytes.BytesIn;
+
+public class ChrBytesInput implements AbcInput {
+    public BytesIn _;
+
+    public ChrBytesInput(BytesIn bytesIn) {
+        this._ = bytesIn;
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-abc/src/main/java/org/noear/solon/serialization/abc/chronicle/bytes/ChrBytesOutput.java
+++ b/solon-projects/solon-serialization/solon-serialization-abc/src/main/java/org/noear/solon/serialization/abc/chronicle/bytes/ChrBytesOutput.java
@@ -1,0 +1,17 @@
+package org.noear.solon.serialization.abc.chronicle.bytes;
+
+import net.openhft.chronicle.bytes.BytesOut;
+import org.noear.solon.serialization.abc.io.AbcOutput;
+
+public class ChrBytesOutput implements AbcOutput {
+    public BytesOut _ ;
+
+    public ChrBytesOutput(BytesOut bytesOut){
+        this._ = bytesOut;
+    }
+
+    @Override
+    public byte[] toBytes() {
+        return _.bytesForRead().toByteArray();
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-abc/src/main/java/org/noear/solon/serialization/abc/chronicle/bytes/ChrBytesSerializable.java
+++ b/solon-projects/solon-serialization/solon-serialization-abc/src/main/java/org/noear/solon/serialization/abc/chronicle/bytes/ChrBytesSerializable.java
@@ -1,0 +1,11 @@
+package org.noear.solon.serialization.abc.chronicle.bytes;
+
+import org.noear.solon.serialization.abc.io.AbcFactory;
+import org.noear.solon.serialization.abc.io.AbcSerializable;
+
+public interface ChrBytesSerializable extends AbcSerializable<ChrBytesInput, ChrBytesOutput> {
+    @Override
+    default AbcFactory<ChrBytesInput, ChrBytesOutput> serializeFactory(){
+        return ChrBytesFactory.getInstance();
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-abc/src/test/java/features/model/PersonDo.java
+++ b/solon-projects/solon-serialization/solon-serialization-abc/src/test/java/features/model/PersonDo.java
@@ -1,0 +1,25 @@
+package features.model;
+
+import org.noear.solon.serialization.abc.chronicle.bytes.ChrBytesInput;
+import org.noear.solon.serialization.abc.chronicle.bytes.ChrBytesOutput;
+import org.noear.solon.serialization.abc.chronicle.bytes.ChrBytesSerializable;
+
+public class PersonDo implements ChrBytesSerializable {
+    public String name;
+    public int age;
+    public double height;
+
+    @Override
+    public void serializeRead(ChrBytesInput in) {
+        this.name = in._.readUtf8();
+        this.age = in._.readInt();
+        this.height = in._.readDouble();
+    }
+
+    @Override
+    public void serializeWrite(ChrBytesOutput out) {
+        out._.writeUtf8(this.name);
+        out._.writeInt(this.age);
+        out._.writeDouble(this.height);
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-abc/src/test/java/features/test0/PersonTest.java
+++ b/solon-projects/solon-serialization/solon-serialization-abc/src/test/java/features/test0/PersonTest.java
@@ -1,0 +1,30 @@
+package features.test0;
+
+import features.model.PersonDo;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.Test;
+import org.noear.solon.serialization.abc.AbcBytesSerializer;
+
+public class PersonTest {
+    @SneakyThrows
+    @Test
+    public void case1() {
+        PersonDo personDo = new PersonDo();
+        personDo.name = "张三丰";
+        personDo.age = 102;
+        personDo.height = 1.75;
+
+        AbcBytesSerializer serializer = new AbcBytesSerializer();
+        byte[] data = serializer.serialize(personDo);
+        System.out.println(data.length);
+
+        PersonDo personDo2 = (PersonDo) serializer.deserialize(data, PersonDo.class);
+        System.out.println("name:"+personDo2.name +",age:"+personDo2.age+",height:"+personDo2.height);
+
+        assert personDo.name.equals(personDo2.name);
+        assert personDo.age == personDo2.age;
+        assert personDo.height == personDo2.height;
+
+
+    }
+}


### PR DESCRIPTION
chronicle.bytes 官方默认提供了BytesIn和BytesOut
BytesIn 对标 ChrBytesInput
BytesOut 对标 ChrBytesOutput
 
方案1 , PersonDo 你看看如何优化为方案2
public class PersonDo implements ChrBytesSerializable {
    public String name;
    
    public void serializeRead(ChrBytesInput in){
      this.name = in._.readUtf8();
    }
    public void serializeWrite(ChrBytesOutput out){
      out._.writeUtf8(this.name);
    }
}


优化方案2：
public class PersonDo implements ChrBytesSerializable {
    public String name;
    
    public void serializeRead(BytesIn in){
      this.name = in.readUtf8();
    }

    public void serializeWrite(BytesOut out){
      out.writeUtf8(this.name);
    }
}