### PR TITLE
fix(solon-configuration-processor):生成的元数据采用原始名称不做转换

### DIFF
--- a/__test/src/main/java/webapp/demoz_tool/DemoProps.java
+++ b/__test/src/main/java/webapp/demoz_tool/DemoProps.java
@@ -45,7 +45,7 @@ public class DemoProps {
         add("b");
     }};
 
-    private DemoEnum defaultDdemoEnum = DemoEnum.A;
+    private DemoEnum defaultDemoEnum = DemoEnum.A;
 
     private DemoEnumWithValue defaultDemoEnumWithValue = DemoEnumWithValue.B;
 }

--- a/__test/src/test/java/features/tool/BindPropsProcessorTest.java
+++ b/__test/src/test/java/features/tool/BindPropsProcessorTest.java
@@ -44,24 +44,24 @@ public class BindPropsProcessorTest {
         assertThat(ctx.read("$.properties.length()"), greaterThanOrEqualTo(18));
         assertThat(ctx.read("$.hints.length()"), greaterThanOrEqualTo(0));
 
-        checkProperty(ctx, "demo.boolean-value", Boolean.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.byte-value", Byte.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.char-value", Character.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.default-ddemo-enum", DemoEnum.class.getCanonicalName(), canonicalName, (v) -> assertThat(v.toString(), equalTo("a")));
-        checkProperty(ctx, "demo.boolean-value", Boolean.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.default-demo-enum-with-value", DemoEnumWithValue.class.getCanonicalName(), canonicalName, (v) -> assertThat(v.toString(), equalTo("b")));
-        checkProperty(ctx, "demo.default-string-array-value", "java.lang.String[]", canonicalName, (v) -> assertThat(v.toString(), equalTo("[\"a\",\"b\"]")));
-        checkProperty(ctx, "demo.default-value", Boolean.class.getCanonicalName(), canonicalName, (v) -> assertThat(v.toString(), equalTo("true")));
-        checkProperty(ctx, "demo.demo-enum", DemoEnum.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.demo-enum-with-value", DemoEnumWithValue.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.double-value", Double.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.float-value", Float.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.int-value", Integer.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.long-value", Long.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.short-value", Short.class.getCanonicalName(), canonicalName);
-        checkProperty(ctx, "demo.string-array-value", "java.lang.String[]", canonicalName);
-        checkProperty(ctx, "demo.string-list-value", "java.util.List<java.lang.String>", canonicalName);
-        checkProperty(ctx, "demo.string-value", String.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.booleanValue", Boolean.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.byteValue", Byte.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.charValue", Character.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.defaultDemoEnum", DemoEnum.class.getCanonicalName(), canonicalName, (v) -> assertThat(v.toString(), equalTo("a")));
+        checkProperty(ctx, "demo.booleanValue", Boolean.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.defaultDemoEnumWithValue", DemoEnumWithValue.class.getCanonicalName(), canonicalName, (v) -> assertThat(v.toString(), equalTo("b")));
+        checkProperty(ctx, "demo.defaultStringArrayValue", "java.lang.String[]", canonicalName, (v) -> assertThat(v.toString(), equalTo("[\"a\",\"b\"]")));
+        checkProperty(ctx, "demo.defaultValue", Boolean.class.getCanonicalName(), canonicalName, (v) -> assertThat(v.toString(), equalTo("true")));
+        checkProperty(ctx, "demo.demoEnum", DemoEnum.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.demoEnumWithValue", DemoEnumWithValue.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.doubleValue", Double.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.floatValue", Float.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.intValue", Integer.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.longValue", Long.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.shortValue", Short.class.getCanonicalName(), canonicalName);
+        checkProperty(ctx, "demo.stringArrayValue", "java.lang.String[]", canonicalName);
+        checkProperty(ctx, "demo.stringListValue", "java.util.List<java.lang.String>", canonicalName);
+        checkProperty(ctx, "demo.stringValue", String.class.getCanonicalName(), canonicalName);
 
     }
 

--- a/solon-projects/solon-tool/solon-configuration-processor/src/main/java/org/noear/solon/configurationprocessor/metadata/ConfigurationMetadata.java
+++ b/solon-projects/solon-tool/solon-configuration-processor/src/main/java/org/noear/solon/configurationprocessor/metadata/ConfigurationMetadata.java
@@ -18,21 +18,15 @@
 
 package org.noear.solon.configurationprocessor.metadata;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-
-import org.noear.solon.configurationprocessor.support.ConventionUtils;
+import java.util.*;
 
 /**
  * Configuration meta-data.
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
- * @since 1.2.0
  * @see ItemMetadata
+ * @since 1.2.0
  */
 public class ConfigurationMetadata {
 
@@ -50,8 +44,24 @@ public class ConfigurationMetadata {
         this.hints = new LinkedHashMap<>(metadata.hints);
     }
 
+    public static String nestedPrefix(String prefix, String name) {
+        String nestedPrefix = (prefix != null) ? prefix : "";
+        nestedPrefix += nestedPrefix.isEmpty() ? name : "." + name;
+        return nestedPrefix;
+    }
+
+    private static <T extends Comparable<T>> List<T> flattenValues(Map<?, List<T>> map) {
+        List<T> content = new ArrayList<>();
+        for (List<T> values : map.values()) {
+            content.addAll(values);
+        }
+        Collections.sort(content);
+        return content;
+    }
+
     /**
      * Add item meta-data.
+     *
      * @param itemMetadata the meta-data to add
      */
     public void add(ItemMetadata itemMetadata) {
@@ -60,6 +70,7 @@ public class ConfigurationMetadata {
 
     /**
      * Add item meta-data if it's not already present.
+     *
      * @param itemMetadata the meta-data to add
      * @since 2.4.0
      */
@@ -69,6 +80,7 @@ public class ConfigurationMetadata {
 
     /**
      * Add item hint.
+     *
      * @param itemHint the item hint to add
      */
     public void add(ItemHint itemHint) {
@@ -77,6 +89,7 @@ public class ConfigurationMetadata {
 
     /**
      * Merge the content from another {@link ConfigurationMetadata}.
+     *
      * @param metadata the {@link ConfigurationMetadata} instance to merge
      */
     public void merge(ConfigurationMetadata metadata) {
@@ -90,6 +103,7 @@ public class ConfigurationMetadata {
 
     /**
      * Return item meta-data.
+     *
      * @return the items
      */
     public List<ItemMetadata> getItems() {
@@ -98,6 +112,7 @@ public class ConfigurationMetadata {
 
     /**
      * Return hint meta-data.
+     *
      * @return the hints
      */
     public List<ItemHint> getHints() {
@@ -118,8 +133,7 @@ public class ConfigurationMetadata {
             if (deprecation != null) {
                 if (matchingDeprecation == null) {
                     matching.setDeprecation(deprecation);
-                }
-                else {
+                } else {
                     if (deprecation.getReason() != null) {
                         matchingDeprecation.setReason(deprecation.getReason());
                     }
@@ -134,8 +148,7 @@ public class ConfigurationMetadata {
                     }
                 }
             }
-        }
-        else {
+        } else {
             add(this.items, metadata.getName(), metadata, false);
         }
     }
@@ -173,22 +186,6 @@ public class ConfigurationMetadata {
             return true;
         }
         return o1 != null && o1.equals(o2);
-    }
-
-    public static String nestedPrefix(String prefix, String name) {
-        String nestedPrefix = (prefix != null) ? prefix : "";
-        String dashedName = ConventionUtils.toDashedCase(name);
-        nestedPrefix += nestedPrefix.isEmpty() ? dashedName : "." + dashedName;
-        return nestedPrefix;
-    }
-
-    private static <T extends Comparable<T>> List<T> flattenValues(Map<?, List<T>> map) {
-        List<T> content = new ArrayList<>();
-        for (List<T> values : map.values()) {
-            content.addAll(values);
-        }
-        Collections.sort(content);
-        return content;
     }
 
     @Override

--- a/solon-projects/solon-tool/solon-configuration-processor/src/main/java/org/noear/solon/configurationprocessor/metadata/ItemHint.java
+++ b/solon-projects/solon-tool/solon-configuration-processor/src/main/java/org/noear/solon/configurationprocessor/metadata/ItemHint.java
@@ -18,8 +18,6 @@
 
 package org.noear.solon.configurationprocessor.metadata;
 
-import org.noear.solon.configurationprocessor.support.ConventionUtils;
-
 import java.util.*;
 
 /**
@@ -36,110 +34,110 @@ import java.util.*;
  */
 public class ItemHint implements Comparable<ItemHint> {
 
-	private final String name;
+    private final String name;
 
-	private final List<ValueHint> values;
+    private final List<ValueHint> values;
 
-	private final List<ValueProvider> providers;
+    private final List<ValueProvider> providers;
 
-	public ItemHint(String name, List<ValueHint> values, List<ValueProvider> providers) {
-		this.name = toCanonicalName(name);
-		this.values = (values != null) ? new ArrayList<>(values) : new ArrayList<>();
-		this.providers = (providers != null) ? new ArrayList<>(providers) : new ArrayList<>();
-	}
+    public ItemHint(String name, List<ValueHint> values, List<ValueProvider> providers) {
+        this.name = toCanonicalName(name);
+        this.values = (values != null) ? new ArrayList<>(values) : new ArrayList<>();
+        this.providers = (providers != null) ? new ArrayList<>(providers) : new ArrayList<>();
+    }
 
-	private String toCanonicalName(String name) {
-		int dot = name.lastIndexOf('.');
-		if (dot != -1) {
-			String prefix = name.substring(0, dot);
-			String originalName = name.substring(dot);
-			return prefix + ConventionUtils.toDashedCase(originalName);
-		}
-		return ConventionUtils.toDashedCase(name);
-	}
+    public static ItemHint newHint(String name, ValueHint... values) {
+        return new ItemHint(name, Arrays.asList(values), Collections.emptyList());
+    }
 
-	public String getName() {
-		return this.name;
-	}
+    private String toCanonicalName(String name) {
+        int dot = name.lastIndexOf('.');
+        if (dot != -1) {
+            String prefix = name.substring(0, dot);
+            String originalName = name.substring(dot);
+            return prefix + originalName;
+        }
+        return name;
+    }
 
-	public List<ValueHint> getValues() {
-		return Collections.unmodifiableList(this.values);
-	}
+    public String getName() {
+        return this.name;
+    }
 
-	public List<ValueProvider> getProviders() {
-		return Collections.unmodifiableList(this.providers);
-	}
+    public List<ValueHint> getValues() {
+        return Collections.unmodifiableList(this.values);
+    }
 
-	@Override
-	public int compareTo(ItemHint other) {
-		return getName().compareTo(other.getName());
-	}
+    public List<ValueProvider> getProviders() {
+        return Collections.unmodifiableList(this.providers);
+    }
 
-	public static ItemHint newHint(String name, ValueHint... values) {
-		return new ItemHint(name, Arrays.asList(values), Collections.emptyList());
-	}
+    @Override
+    public int compareTo(ItemHint other) {
+        return getName().compareTo(other.getName());
+    }
 
-	@Override
-	public String toString() {
-		return "ItemHint{name='" + this.name + "', values=" + this.values + ", providers=" + this.providers + '}';
-	}
+    @Override
+    public String toString() {
+        return "ItemHint{name='" + this.name + "', values=" + this.values + ", providers=" + this.providers + '}';
+    }
 
-	/**
-	 * A hint for a value.
-	 */
-	public static class ValueHint {
+    /**
+     * A hint for a value.
+     */
+    public static class ValueHint {
 
-		private final Object value;
+        private final Object value;
 
-		private final String description;
+        private final String description;
 
-		public ValueHint(Object value, String description) {
-			this.value = value;
-			this.description = description;
-		}
+        public ValueHint(Object value, String description) {
+            this.value = value;
+            this.description = description;
+        }
 
-		public Object getValue() {
-			return this.value;
-		}
+        public Object getValue() {
+            return this.value;
+        }
 
-		public String getDescription() {
-			return this.description;
-		}
+        public String getDescription() {
+            return this.description;
+        }
 
-		@Override
-		public String toString() {
-			return "ValueHint{value=" + this.value + ", description='" + this.description + '\'' + '}';
-		}
+        @Override
+        public String toString() {
+            return "ValueHint{value=" + this.value + ", description='" + this.description + '\'' + '}';
+        }
 
-	}
+    }
 
-	/**
-	 * A value provider.
-	 */
-	public static class ValueProvider {
+    /**
+     * A value provider.
+     */
+    public static class ValueProvider {
 
-		private final String name;
+        private final String name;
 
-		private final Map<String, Object> parameters;
+        private final Map<String, Object> parameters;
 
-		public ValueProvider(String name, Map<String, Object> parameters) {
-			this.name = name;
-			this.parameters = parameters;
-		}
+        public ValueProvider(String name, Map<String, Object> parameters) {
+            this.name = name;
+            this.parameters = parameters;
+        }
 
-		public String getName() {
-			return this.name;
-		}
+        public String getName() {
+            return this.name;
+        }
 
-		public Map<String, Object> getParameters() {
-			return this.parameters;
-		}
+        public Map<String, Object> getParameters() {
+            return this.parameters;
+        }
 
-		@Override
-		public String toString() {
-			return "ValueProvider{name='" + this.name + "', parameters=" + this.parameters + '}';
-		}
+        @Override
+        public String toString() {
+            return "ValueProvider{name='" + this.name + "', parameters=" + this.parameters + '}';
+        }
 
-	}
+    }
 
 }

--- a/solon-projects/solon-tool/solon-configuration-processor/src/main/java/org/noear/solon/configurationprocessor/metadata/ItemMetadata.java
+++ b/solon-projects/solon-tool/solon-configuration-processor/src/main/java/org/noear/solon/configurationprocessor/metadata/ItemMetadata.java
@@ -19,226 +19,225 @@
 package org.noear.solon.configurationprocessor.metadata;
 
 import java.util.Locale;
-import org.noear.solon.configurationprocessor.support.ConventionUtils;
 
 /**
  * A group or property meta-data item from some {@link ConfigurationMetadata}.
  *
  * @author Stephane Nicoll
  * @author Phillip Webb
- * @since 1.2.0
  * @see ConfigurationMetadata
+ * @since 1.2.0
  */
 public final class ItemMetadata implements Comparable<ItemMetadata> {
 
-	private final ItemType itemType;
+    private final ItemType itemType;
 
-	private String name;
+    private String name;
 
-	private String type;
+    private String type;
 
-	private String description;
+    private String description;
 
-	private String sourceType;
+    private String sourceType;
 
-	private String sourceMethod;
+    private String sourceMethod;
 
-	private Object defaultValue;
+    private Object defaultValue;
 
-	private ItemDeprecation deprecation;
+    private ItemDeprecation deprecation;
 
-	ItemMetadata(ItemType itemType, String prefix, String name, String type, String sourceType, String sourceMethod,
+    ItemMetadata(ItemType itemType, String prefix, String name, String type, String sourceType, String sourceMethod,
                  String description, Object defaultValue, ItemDeprecation deprecation) {
-		this.itemType = itemType;
-		this.name = buildName(prefix, name);
-		this.type = type;
-		this.sourceType = sourceType;
-		this.sourceMethod = sourceMethod;
-		this.description = description;
-		this.defaultValue = defaultValue;
-		this.deprecation = deprecation;
-	}
+        this.itemType = itemType;
+        this.name = buildName(prefix, name);
+        this.type = type;
+        this.sourceType = sourceType;
+        this.sourceMethod = sourceMethod;
+        this.description = description;
+        this.defaultValue = defaultValue;
+        this.deprecation = deprecation;
+    }
 
-	private String buildName(String prefix, String name) {
-		StringBuilder fullName = new StringBuilder();
-		if (prefix != null) {
-			if (prefix.endsWith(".")) {
-				prefix = prefix.substring(0, prefix.length() - 1);
-			}
-			fullName.append(prefix);
-		}
-		if (name != null) {
-			if (fullName.length() > 0) {
-				fullName.append('.');
-			}
-			fullName.append(ConventionUtils.toDashedCase(name));
-		}
-		return fullName.toString();
-	}
+    public static ItemMetadata newGroup(String name, String type, String sourceType, String sourceMethod) {
+        return new ItemMetadata(ItemType.GROUP, name, null, type, sourceType, sourceMethod, null, null, null);
+    }
 
-	public boolean isOfItemType(ItemType itemType) {
-		return this.itemType == itemType;
-	}
+    public static ItemMetadata newProperty(String prefix, String name, String type, String sourceType,
+                                           String sourceMethod, String description, Object defaultValue, ItemDeprecation deprecation) {
+        return new ItemMetadata(ItemType.PROPERTY, prefix, name, type, sourceType, sourceMethod, description,
+                defaultValue, deprecation);
+    }
 
-	public boolean hasSameType(ItemMetadata metadata) {
-		return this.itemType == metadata.itemType;
-	}
+    public static String newItemMetadataPrefix(String prefix, String suffix) {
+        return prefix.toLowerCase(Locale.ENGLISH) + suffix;
+    }
 
-	public String getName() {
-		return this.name;
-	}
+    private String buildName(String prefix, String name) {
+        StringBuilder fullName = new StringBuilder();
+        if (prefix != null) {
+            if (prefix.endsWith(".")) {
+                prefix = prefix.substring(0, prefix.length() - 1);
+            }
+            fullName.append(prefix);
+        }
+        if (name != null) {
+            if (fullName.length() > 0) {
+                fullName.append('.');
+            }
+            fullName.append(name);
+        }
+        return fullName.toString();
+    }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+    public boolean isOfItemType(ItemType itemType) {
+        return this.itemType == itemType;
+    }
 
-	public String getType() {
-		return this.type;
-	}
+    public boolean hasSameType(ItemMetadata metadata) {
+        return this.itemType == metadata.itemType;
+    }
 
-	public void setType(String type) {
-		this.type = type;
-	}
+    public String getName() {
+        return this.name;
+    }
 
-	public String getDescription() {
-		return this.description;
-	}
+    public void setName(String name) {
+        this.name = name;
+    }
 
-	public void setDescription(String description) {
-		this.description = description;
-	}
+    public String getType() {
+        return this.type;
+    }
 
-	public String getSourceType() {
-		return this.sourceType;
-	}
+    public void setType(String type) {
+        this.type = type;
+    }
 
-	public void setSourceType(String sourceType) {
-		this.sourceType = sourceType;
-	}
+    public String getDescription() {
+        return this.description;
+    }
 
-	public String getSourceMethod() {
-		return this.sourceMethod;
-	}
+    public void setDescription(String description) {
+        this.description = description;
+    }
 
-	public void setSourceMethod(String sourceMethod) {
-		this.sourceMethod = sourceMethod;
-	}
+    public String getSourceType() {
+        return this.sourceType;
+    }
 
-	public Object getDefaultValue() {
-		return this.defaultValue;
-	}
+    public void setSourceType(String sourceType) {
+        this.sourceType = sourceType;
+    }
 
-	public void setDefaultValue(Object defaultValue) {
-		this.defaultValue = defaultValue;
-	}
+    public String getSourceMethod() {
+        return this.sourceMethod;
+    }
 
-	public ItemDeprecation getDeprecation() {
-		return this.deprecation;
-	}
+    public void setSourceMethod(String sourceMethod) {
+        this.sourceMethod = sourceMethod;
+    }
 
-	public void setDeprecation(ItemDeprecation deprecation) {
-		this.deprecation = deprecation;
-	}
+    public Object getDefaultValue() {
+        return this.defaultValue;
+    }
 
-	@Override
-	public boolean equals(Object o) {
-		if (this == o) {
-			return true;
-		}
-		if (o == null || getClass() != o.getClass()) {
-			return false;
-		}
-		ItemMetadata other = (ItemMetadata) o;
-		boolean result = true;
-		result = result && nullSafeEquals(this.itemType, other.itemType);
-		result = result && nullSafeEquals(this.name, other.name);
-		result = result && nullSafeEquals(this.type, other.type);
-		result = result && nullSafeEquals(this.description, other.description);
-		result = result && nullSafeEquals(this.sourceType, other.sourceType);
-		result = result && nullSafeEquals(this.sourceMethod, other.sourceMethod);
-		result = result && nullSafeEquals(this.defaultValue, other.defaultValue);
-		result = result && nullSafeEquals(this.deprecation, other.deprecation);
-		return result;
-	}
+    public void setDefaultValue(Object defaultValue) {
+        this.defaultValue = defaultValue;
+    }
 
-	@Override
-	public int hashCode() {
-		int result = nullSafeHashCode(this.itemType);
-		result = 31 * result + nullSafeHashCode(this.name);
-		result = 31 * result + nullSafeHashCode(this.type);
-		result = 31 * result + nullSafeHashCode(this.description);
-		result = 31 * result + nullSafeHashCode(this.sourceType);
-		result = 31 * result + nullSafeHashCode(this.sourceMethod);
-		result = 31 * result + nullSafeHashCode(this.defaultValue);
-		result = 31 * result + nullSafeHashCode(this.deprecation);
-		return result;
-	}
+    public ItemDeprecation getDeprecation() {
+        return this.deprecation;
+    }
 
-	private boolean nullSafeEquals(Object o1, Object o2) {
-		if (o1 == o2) {
-			return true;
-		}
-		if (o1 == null || o2 == null) {
-			return false;
-		}
-		return o1.equals(o2);
-	}
+    public void setDeprecation(ItemDeprecation deprecation) {
+        this.deprecation = deprecation;
+    }
 
-	private int nullSafeHashCode(Object o) {
-		return (o != null) ? o.hashCode() : 0;
-	}
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ItemMetadata other = (ItemMetadata) o;
+        boolean result = true;
+        result = result && nullSafeEquals(this.itemType, other.itemType);
+        result = result && nullSafeEquals(this.name, other.name);
+        result = result && nullSafeEquals(this.type, other.type);
+        result = result && nullSafeEquals(this.description, other.description);
+        result = result && nullSafeEquals(this.sourceType, other.sourceType);
+        result = result && nullSafeEquals(this.sourceMethod, other.sourceMethod);
+        result = result && nullSafeEquals(this.defaultValue, other.defaultValue);
+        result = result && nullSafeEquals(this.deprecation, other.deprecation);
+        return result;
+    }
 
-	@Override
-	public String toString() {
-		StringBuilder string = new StringBuilder(this.name);
-		buildToStringProperty(string, "type", this.type);
-		buildToStringProperty(string, "sourceType", this.sourceType);
-		buildToStringProperty(string, "description", this.description);
-		buildToStringProperty(string, "defaultValue", this.defaultValue);
-		buildToStringProperty(string, "deprecation", this.deprecation);
-		return string.toString();
-	}
+    @Override
+    public int hashCode() {
+        int result = nullSafeHashCode(this.itemType);
+        result = 31 * result + nullSafeHashCode(this.name);
+        result = 31 * result + nullSafeHashCode(this.type);
+        result = 31 * result + nullSafeHashCode(this.description);
+        result = 31 * result + nullSafeHashCode(this.sourceType);
+        result = 31 * result + nullSafeHashCode(this.sourceMethod);
+        result = 31 * result + nullSafeHashCode(this.defaultValue);
+        result = 31 * result + nullSafeHashCode(this.deprecation);
+        return result;
+    }
 
-	private void buildToStringProperty(StringBuilder string, String property, Object value) {
-		if (value != null) {
-			string.append(" ").append(property).append(":").append(value);
-		}
-	}
+    private boolean nullSafeEquals(Object o1, Object o2) {
+        if (o1 == o2) {
+            return true;
+        }
+        if (o1 == null || o2 == null) {
+            return false;
+        }
+        return o1.equals(o2);
+    }
 
-	@Override
-	public int compareTo(ItemMetadata o) {
-		return getName().compareTo(o.getName());
-	}
+    private int nullSafeHashCode(Object o) {
+        return (o != null) ? o.hashCode() : 0;
+    }
 
-	public static ItemMetadata newGroup(String name, String type, String sourceType, String sourceMethod) {
-		return new ItemMetadata(ItemType.GROUP, name, null, type, sourceType, sourceMethod, null, null, null);
-	}
+    @Override
+    public String toString() {
+        StringBuilder string = new StringBuilder(this.name);
+        buildToStringProperty(string, "type", this.type);
+        buildToStringProperty(string, "sourceType", this.sourceType);
+        buildToStringProperty(string, "description", this.description);
+        buildToStringProperty(string, "defaultValue", this.defaultValue);
+        buildToStringProperty(string, "deprecation", this.deprecation);
+        return string.toString();
+    }
 
-	public static ItemMetadata newProperty(String prefix, String name, String type, String sourceType,
-			String sourceMethod, String description, Object defaultValue, ItemDeprecation deprecation) {
-		return new ItemMetadata(ItemType.PROPERTY, prefix, name, type, sourceType, sourceMethod, description,
-				defaultValue, deprecation);
-	}
+    private void buildToStringProperty(StringBuilder string, String property, Object value) {
+        if (value != null) {
+            string.append(" ").append(property).append(":").append(value);
+        }
+    }
 
-	public static String newItemMetadataPrefix(String prefix, String suffix) {
-		return prefix.toLowerCase(Locale.ENGLISH) + ConventionUtils.toDashedCase(suffix);
-	}
+    @Override
+    public int compareTo(ItemMetadata o) {
+        return getName().compareTo(o.getName());
+    }
 
-	/**
-	 * The item type.
-	 */
-	public enum ItemType {
+    /**
+     * The item type.
+     */
+    public enum ItemType {
 
-		/**
-		 * Group item type.
-		 */
-		GROUP,
+        /**
+         * Group item type.
+         */
+        GROUP,
 
-		/**
-		 * Property item type.
-		 */
-		PROPERTY
+        /**
+         * Property item type.
+         */
+        PROPERTY
 
-	}
+    }
 
 }


### PR DESCRIPTION
之前参考spring处理策略，将大写字母转换成中划线写法，目前已改成使用原名