### PR TITLE
feat: Support Qdrant vector storage

### DIFF
--- a/solon-projects/solon-ai/solon-ai-repo-qdrant/pom.xml
+++ b/solon-projects/solon-ai/solon-ai-repo-qdrant/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.noear</groupId>
+        <artifactId>solon-parent</artifactId>
+        <version>3.1.0</version>
+        <relativePath>../../../solon-parent/pom.xml</relativePath>
+    </parent>
+    
+    <artifactId>solon-ai-repo-qdrant</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon-ai</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon-flow</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon-logging-simple</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon-ai-load-markdown</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon-ai-load-html</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    <!-- Qdrant Dependencies -->
+		<dependency>
+			<groupId>io.qdrant</groupId>
+			<artifactId>client</artifactId>
+			<version>1.13.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>33.1.0-jre</version>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-protobuf</artifactId>
+			<version>1.65.1</version>
+		</dependency>
+        <dependency>
+        <groupId>com.google.code.gson</groupId>
+        <artifactId>gson</artifactId>
+        <version>2.12.1</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/solon-projects/solon-ai/solon-ai-repo-qdrant/pom.xml
+++ b/solon-projects/solon-ai/solon-ai-repo-qdrant/pom.xml
@@ -73,9 +73,9 @@
 			<version>1.65.1</version>
 		</dependency>
         <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>2.12.1</version>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.12.1</version>
         </dependency>
 
     </dependencies>

--- a/solon-projects/solon-ai/solon-ai-repo-qdrant/src/main/java/org/noear/solon/ai/rag/repository/QdrantRepository.java
+++ b/solon-projects/solon-ai/solon-ai-repo-qdrant/src/main/java/org/noear/solon/ai/rag/repository/QdrantRepository.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.ai.rag.repository;
+
+import io.qdrant.client.PointIdFactory;
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.grpc.Collections.Distance;
+import io.qdrant.client.grpc.Collections.VectorParams;
+import io.qdrant.client.grpc.JsonWithInt;
+import io.qdrant.client.grpc.Points.*;
+
+import org.noear.solon.Utils;
+import org.noear.solon.ai.embedding.EmbeddingModel;
+import org.noear.solon.ai.rag.Document;
+import org.noear.solon.ai.rag.RepositoryStorable;
+import org.noear.solon.ai.rag.util.SimilarityUtil;
+import org.noear.solon.ai.rag.util.ListUtil;
+import org.noear.solon.ai.rag.util.QueryCondition;
+
+import com.google.gson.Gson;
+import org.noear.solon.lang.Preview;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.qdrant.client.QueryFactory.nearest;
+import static io.qdrant.client.VectorsFactory.vectors;
+import static io.qdrant.client.ValueFactory.value;
+import static io.qdrant.client.WithPayloadSelectorFactory.include;
+import static io.qdrant.client.WithVectorsSelectorFactory.enable;
+
+/**
+ * Qdrant 矢量存储知识库
+ *
+ * @author Anush008
+ *
+ * @since 3.1.2
+ */
+@Preview("3.1.2")
+public class QdrantRepository implements RepositoryStorable {
+    private static final String DEFAULT_CONTENT_KEY = "content";
+    private static final String DEFAULT_METADATA_KEY = "metadata";
+
+    private final String contentKey;
+    private final String metadataKey;
+
+    private final EmbeddingModel embeddingModel;
+    private final QdrantClient client;
+    private final String collectionName;
+    private final Gson gson = new Gson();
+
+    public QdrantRepository(EmbeddingModel embeddingModel, QdrantClient client, String collectionName) {
+        this(embeddingModel, client, collectionName, DEFAULT_CONTENT_KEY, DEFAULT_METADATA_KEY);
+    }
+
+    public QdrantRepository(EmbeddingModel embeddingModel, QdrantClient client, String collectionName,
+            String contentKey, String metadataKey) {
+        this.embeddingModel = embeddingModel;
+        this.client = client;
+        this.collectionName = collectionName;
+        this.contentKey = contentKey;
+        this.metadataKey = metadataKey;
+
+        initRepository();
+    }
+
+    public void initRepository() {
+        try {
+            boolean exists = client.collectionExistsAsync(collectionName).get();
+
+            if (!exists) {
+                int dimensions = embeddingModel.dimensions();
+
+                client.createCollectionAsync(collectionName,
+                        VectorParams.newBuilder().setSize(dimensions).setDistance(Distance.Cosine).build()).get();
+
+            }
+        } catch (InterruptedException | ExecutionException | IOException e) {
+            throw new RuntimeException("Failed to initialize Qdrant repository", e);
+        }
+    }
+
+    public void dropRepository() {
+        try {
+            client.deleteCollectionAsync(collectionName).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException("Failed to drop Qdrant repository", e);
+        }
+    }
+
+    @Override
+    public void insert(List<Document> documents) throws IOException {
+        if (Utils.isEmpty(documents)) {
+            return;
+        }
+
+        try {
+            for (List<Document> sub : ListUtil.partition(documents, 20)) {
+                embeddingModel.embed(sub);
+
+                List<PointStruct> points = sub.stream().map(this::toPointStruct).collect(Collectors.toList());
+
+                client.upsertAsync(
+                        UpsertPoints.newBuilder().setCollectionName(collectionName).addAllPoints(points).build()).get();
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IOException("Failed to insert documents into Qdrant", e);
+        }
+    }
+
+    @Override
+    public void delete(String... ids) throws IOException {
+        try {
+            List<PointId> pointIds = Arrays.stream(ids).map(id -> PointId.newBuilder().setUuid(id).build())
+                    .collect(Collectors.toList());
+
+            client.deleteAsync(collectionName, pointIds).get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IOException("Failed to delete documents from Qdrant", e);
+        }
+    }
+
+    @Override
+    public boolean exists(String id) throws IOException {
+        try {
+            List<RetrievedPoint> points = client.retrieveAsync(GetPoints.newBuilder().setCollectionName(collectionName)
+                    .addIds(PointIdFactory.id(UUID.fromString(id))).build(), null).get();
+
+            return points.size() > 0;
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IOException("Failed to check document existence in Qdrant", e);
+        }
+    }
+
+    @Override
+    public List<Document> search(QueryCondition condition) throws IOException {
+        try {
+            float[] queryVector = embeddingModel.embed(condition.getQuery());
+
+            List<ScoredPoint> points = client.queryAsync(QueryPoints.newBuilder().setCollectionName(collectionName)
+                    .setQuery(nearest(queryVector)).setLimit(condition.getLimit())
+                    .setScoreThreshold((float) condition.getSimilarityThreshold())
+                    .setWithPayload(include(Arrays.asList(contentKey, metadataKey))).setWithVectors(enable(true))
+                    .build()).get();
+
+            Stream<Document> docs = points.stream().map(this::toDocument);
+
+            return SimilarityUtil.filter(condition, docs);
+        } catch (InterruptedException | ExecutionException e) {
+            throw new IOException("Failed to search documents in Qdrant", e);
+        }
+    }
+
+    private PointStruct toPointStruct(Document doc) {
+        if (doc.getId() == null) {
+            doc.id(Utils.uuid());
+        }
+
+        Map<String, JsonWithInt.Value> payload = new HashMap<>();
+
+        payload.put(contentKey, value(doc.getContent()));
+
+        if (doc.getMetadata() != null) {
+            String metadataJson = gson.toJson(doc.getMetadata());
+            payload.put("metadata", value(metadataJson));
+        }
+
+        return PointStruct.newBuilder().setId(PointIdFactory.id(UUID.fromString(doc.getId())))
+                .setVectors(vectors(doc.getEmbedding())).putAllPayload(payload).build();
+    }
+
+    @SuppressWarnings("unchecked")
+    private Document toDocument(ScoredPoint scoredPoint) {
+        String id = scoredPoint.getId().getUuid();
+        float score = scoredPoint.getScore();
+
+        Map<String, JsonWithInt.Value> payload = scoredPoint.getPayloadMap();
+
+        String content = payload.get(contentKey).getStringValue();
+
+        Map<String, Object> metadata = null;
+        if (payload.containsKey(metadataKey)) {
+            String metadataJson = payload.get(metadataKey).getStringValue();
+            metadata = gson.fromJson(metadataJson, Map.class);
+        }
+
+        float[] embedding = listToFloatArray(scoredPoint.getVectors().getVector().getDataList());
+
+        Document doc = new Document(id, content, metadata, score);
+        return doc.embedding(embedding);
+    }
+
+    private float[] listToFloatArray(List<Float> list) {
+        float[] array = new float[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            array[i] = list.get(i);
+        }
+        return array;
+    }
+}

--- a/solon-projects/solon-ai/solon-ai-repo-qdrant/src/test/java/org/noear/solon/ai/rag/repository/QdrantRepositoryTest.java
+++ b/solon-projects/solon-ai/solon-ai-repo-qdrant/src/test/java/org/noear/solon/ai/rag/repository/QdrantRepositoryTest.java
@@ -1,0 +1,89 @@
+package org.noear.solon.ai.rag.repository;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import io.qdrant.client.QdrantClient;
+import io.qdrant.client.QdrantGrpcClient;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.noear.solon.ai.embedding.EmbeddingModel;
+import org.noear.solon.ai.rag.Document;
+import org.noear.solon.ai.rag.DocumentLoader;
+import org.noear.solon.ai.rag.RepositoryStorable;
+import org.noear.solon.ai.rag.loader.HtmlSimpleLoader;
+import org.noear.solon.ai.rag.loader.MarkdownLoader;
+import org.noear.solon.ai.rag.splitter.RegexTextSplitter;
+import org.noear.solon.ai.rag.splitter.SplitterPipeline;
+import org.noear.solon.ai.rag.splitter.TokenSizeTextSplitter;
+import org.noear.solon.net.http.HttpUtils;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TestUtils {
+    public static EmbeddingModel getEmbeddingModel() {
+        final String apiUrl = "http://127.0.0.1:11434/api/embed";
+        final String provider = "ollama";
+        final String model = "all-minilm";//
+
+        return EmbeddingModel.of(apiUrl).provider(provider).model(model).build();
+    }
+}
+
+public class QdrantRepositoryTest {
+    private QdrantClient client = new QdrantClient(QdrantGrpcClient.newBuilder("localhost", 6334, false).build());
+    private String collectionName = "solonAiRepo";
+    private QdrantRepository repository;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        repository = new QdrantRepository(TestUtils.getEmbeddingModel(), client, collectionName);
+
+        load(repository, "https://solon.noear.org/article/about?format=md");
+        load(repository, "https://h5.noear.org/more.htm");
+        load(repository, "https://h5.noear.org/readme.htm");
+    }
+
+    @AfterEach
+    public void cleanup() {
+        repository.dropRepository();
+    }
+
+    @Test
+    public void case1_search() throws Exception {
+        List<Document> list = repository.search("solon");
+        assert list.size() == 4;
+
+        list = repository.search("vert.x");
+        assert list.size() == 0;
+
+        Document doc = new Document("Test content");
+        repository.insert(Collections.singletonList(doc));
+        String key = doc.getId();
+
+        assertTrue(repository.exists(key), "Document should exist after storing");
+
+        repository.delete(doc.getId());
+        assertFalse(repository.exists(key), "Document should not exist after removal");
+    }
+
+    private void load(RepositoryStorable repository, String url) throws IOException {
+        String text = HttpUtils.http(url).get();
+
+        DocumentLoader loader = null;
+        if (text.contains("</html>")) {
+            loader = new HtmlSimpleLoader(text.getBytes(StandardCharsets.UTF_8));
+        } else {
+            loader = new MarkdownLoader(text.getBytes(StandardCharsets.UTF_8));
+        }
+
+        List<Document> documents = new SplitterPipeline().next(new RegexTextSplitter())
+                .next(new TokenSizeTextSplitter(500)).split(loader.load());
+
+        repository.insert(documents);
+    }
+}


### PR DESCRIPTION
## Description

Hey 👋.

This PR adds support for Qdrant -  https://qdrant.tech/ to be used as vector storage in Solon.

Integration tests are included that require Qdrant and Llama instances running.

```bash
docker run -d -p 6334:6334 -p 6333:6333 qdrant/qdrant
```


```bash
docker run -d -p 11434:11434 --name ollama ollama/ollama
docker exec -it ollama ollama pull all-minilm
````

```bash
mvn test
```