### PR TITLE
新增 javabin 安全序列化模块和接入入口 (#421)

### DIFF
--- a/__release/solon-base-bundle5/pom.xml
+++ b/__release/solon-base-bundle5/pom.xml
@@ -27,6 +27,7 @@
         <module>../../solon-projects/solon-serialization/solon-serialization-gson</module>
         <module>../../solon-projects/solon-serialization/solon-serialization-fury</module>
         <module>../../solon-projects/solon-serialization/solon-serialization-hessian</module>
+        <module>../../solon-projects/solon-serialization/solon-serialization-javabin</module>
         <module>../../solon-projects/solon-serialization/solon-serialization-protostuff</module>
         <module>../../solon-projects/solon-serialization/solon-serialization-properties</module>
         <module>../../solon-projects/solon-serialization/solon-serialization-kryo</module>

--- a/solon-parent/pom.xml
+++ b/solon-parent/pom.xml
@@ -1165,6 +1165,11 @@
             </dependency>
             <dependency>
                 <groupId>org.noear</groupId>
+                <artifactId>solon-serialization-javabin</artifactId>
+                <version>${solon.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.noear</groupId>
                 <artifactId>solon-serialization-fury</artifactId>
                 <version>${solon.version}</version>
             </dependency>

--- a/solon-projects/solon-data/solon-cache/src/main/java/org/noear/solon/data/cache/impl/ObjectInputStreamEx.java
+++ b/solon-projects/solon-data/solon-cache/src/main/java/org/noear/solon/data/cache/impl/ObjectInputStreamEx.java
@@ -23,11 +23,15 @@ import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
 
 /**
- * ObjectInputStream 增加类加载控制
+ * ObjectInputStream 增加类加载控制。
  *
  * @author noear
  * @since 2.8
+ * @deprecated since 3.11 -- 仅做 classloader 切换，不做类白名单过滤。
+ * 请改用 {@code solon-serialization-javabin} 模块下的
+ * {@code org.noear.solon.serialization.javabin.SafeObjectInputStream}。
  */
+@Deprecated
 public class ObjectInputStreamEx extends ObjectInputStream {
     private ClassLoader loader;
 

--- a/solon-projects/solon-serialization/solon-serialization-javabin/NOTICE
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/NOTICE
@@ -1,0 +1,20 @@
+Copyright 2017-2025 noear.org and authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This project includes:
+  JUnit Jupiter (Aggregator) under Eclipse Public License v2.0
+  JUnit Jupiter API under Eclipse Public License v2.0
+  SLF4J API Module under MIT
+  solon under The Apache Software License, Version 2.0
+  solon-test under The Apache Software License, Version 2.0

--- a/solon-projects/solon-serialization/solon-serialization-javabin/README.md
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/README.md
@@ -1,0 +1,26 @@
+solon-serialization-javabin
+==========
+
+基于 Java 原生 `ObjectInputStream` / `ObjectOutputStream` 的 javabin 序列化实现。
+反序列化时带类过滤。
+
+## 使用
+
+```java
+JavabinSerializer ser = new JavabinSerializer();
+ser.classFilter().allow("com.yourapp.");
+redisCacheService.serializer(ser);
+```
+
+也可以通过配置放宽：
+
+```yaml
+solon.serialization.javabin:
+  allow:
+    - "com.yourapp."
+  deny:
+    - "com.yourapp.internal."
+  unrestricted: false
+```
+
+默认过滤器允许常见 JDK 类型，可通过 `allow(...)` / `deny(...)` 调整；如需平滑迁移，也可以配合 `unrestricted: true` 先按黑名单模式接入。

--- a/solon-projects/solon-serialization/solon-serialization-javabin/pom.xml
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.noear</groupId>
+        <artifactId>solon-parent</artifactId>
+        <version>3.10.4-SNAPSHOT</version>
+        <relativePath>../../../solon-parent/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>solon-serialization-javabin</artifactId>
+    <name>${project.artifactId}</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.noear</groupId>
+            <artifactId>solon-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/main/java/org/noear/solon/serialization/javabin/JavabinClassFilter.java
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/main/java/org/noear/solon/serialization/javabin/JavabinClassFilter.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.serialization.javabin;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+/**
+ * Javabin 反序列化类过滤器。
+ */
+public class JavabinClassFilter {
+
+    private final Set<String> allowPatterns = new LinkedHashSet<>();
+    private final Set<String> denyPatterns = new LinkedHashSet<>();
+    private boolean allowAll;
+
+    public static JavabinClassFilter defaults() {
+        JavabinClassFilter f = new JavabinClassFilter();
+        f.allow("java.lang.");
+        f.allow("java.util.");
+        f.allow("java.time.");
+        f.allow("java.math.");
+        f.allow("java.net.URI");
+        f.allow("java.net.URL");
+        f.allow("java.net.InetAddress");
+        f.allow("java.net.Inet4Address");
+        f.allow("java.net.Inet6Address");
+        f.allow("java.sql.");
+
+        f.deny("java.lang.Runtime");
+        f.deny("java.lang.Process");
+        f.deny("java.lang.ProcessBuilder");
+        f.deny("java.lang.ProcessImpl");
+        f.deny("java.lang.UNIXProcess");
+        f.deny("javax.management.");
+        f.deny("javax.naming.");
+        f.deny("javax.script.");
+        f.deny("com.sun.rowset.");
+        f.deny("sun.reflect.annotation.");
+        f.deny("sun.rmi.");
+        f.deny("java.rmi.");
+        return f;
+    }
+
+    public static JavabinClassFilter unrestricted() {
+        JavabinClassFilter f = new JavabinClassFilter();
+        f.allowAll = true;
+        return f;
+    }
+
+    public JavabinClassFilter allow(String pattern) {
+        if (pattern != null && pattern.length() > 0) {
+            allowPatterns.add(pattern);
+        }
+        return this;
+    }
+
+    public JavabinClassFilter deny(String pattern) {
+        if (pattern != null && pattern.length() > 0) {
+            denyPatterns.add(pattern);
+        }
+        return this;
+    }
+
+    public JavabinClassFilter allowAll(boolean allowAll) {
+        this.allowAll = allowAll;
+        return this;
+    }
+
+    public boolean isAllowAll() {
+        return allowAll;
+    }
+
+    public boolean isAllowed(String className) {
+        if (className == null || className.length() == 0) {
+            return false;
+        }
+
+        String t = className;
+        while (t.length() > 0 && t.charAt(0) == '[') {
+            t = t.substring(1);
+        }
+        if (t.length() == 0) {
+            return false;
+        }
+        if (t.length() == 1) {
+            return true;
+        }
+        if (t.charAt(0) == 'L' && t.charAt(t.length() - 1) == ';') {
+            t = t.substring(1, t.length() - 1);
+        }
+
+        for (String deny : denyPatterns) {
+            if (matches(t, deny)) {
+                return false;
+            }
+        }
+        if (allowAll) {
+            return true;
+        }
+        for (String allow : allowPatterns) {
+            if (matches(t, allow)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean matches(String name, String pattern) {
+        if (pattern.endsWith(".")) {
+            return name.startsWith(pattern);
+        }
+        if (name.equals(pattern)) {
+            return true;
+        }
+        return name.length() > pattern.length()
+                && name.startsWith(pattern)
+                && name.charAt(pattern.length()) == '$';
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/main/java/org/noear/solon/serialization/javabin/JavabinSerializer.java
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/main/java/org/noear/solon/serialization/javabin/JavabinSerializer.java
@@ -13,30 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.noear.solon.data.cache.impl;
+package org.noear.solon.serialization.javabin;
 
 import org.noear.solon.core.serialize.Serializer;
 import org.noear.solon.core.util.ClassUtil;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.lang.reflect.Type;
 import java.util.Base64;
 
 /**
  * Javabin 序列化实现。
- *
- * @author noear
- * @since 2.5
- * @deprecated since 3.11 -- 此实现未对反序列化类做白名单过滤（CWE-502）。
- * 请改用 {@code solon-serialization-javabin} 模块下的
- * {@code org.noear.solon.serialization.javabin.JavabinSerializer}；
- * 它默认按 {@code JavabinClassFilter.defaults()} 过滤，可通过
- * {@code classFilter().allow(...)} 放宽，并且覆盖了 {@code resolveProxyClass}
- * 防止动态代理绕过。
  */
-@Deprecated
 public class JavabinSerializer implements Serializer<String> {
+
     public static final JavabinSerializer instance = new JavabinSerializer();
+
+    private final JavabinClassFilter classFilter;
+
+    public JavabinSerializer() {
+        this(JavabinClassFilter.defaults());
+    }
+
+    public JavabinSerializer(JavabinClassFilter classFilter) {
+        this.classFilter = (classFilter != null ? classFilter : JavabinClassFilter.defaults());
+    }
+
+    public JavabinClassFilter classFilter() {
+        return classFilter;
+    }
 
     @Override
     public String name() {
@@ -54,52 +64,44 @@ public class JavabinSerializer implements Serializer<String> {
     }
 
     @Override
-    public Object deserialize(String dta, Type toType) {
+    public Object deserialize(String dta, Type toType) throws IOException {
         if (dta == null) {
             return null;
         }
 
-        //分析类加载器
         ClassLoader loader = ClassUtil.resolveClassLoader(toType);
 
         byte[] bytes = Base64.getDecoder().decode(dta);
         return deserializeDo(loader, bytes);
     }
 
-
     protected byte[] serializeDo(Object object) {
         if (object == null) {
             return null;
-        } else {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
-
-            try {
-                ObjectOutputStream oos = new ObjectOutputStream(baos);
-                oos.writeObject(object);
-                oos.flush();
-            } catch (IOException e) {
-                throw new IllegalArgumentException("Failed to serialize object of type: " + object.getClass(), e);
-            }
-
-            return baos.toByteArray();
         }
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(1024);
+        try {
+            ObjectOutputStream oos = new ObjectOutputStream(baos);
+            oos.writeObject(object);
+            oos.flush();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to serialize object of type: " + object.getClass(), e);
+        }
+        return baos.toByteArray();
     }
 
-    /**
-     * 反序列化
-     */
-    protected Object deserializeDo(ClassLoader loader, byte[] bytes) {
+    protected Object deserializeDo(ClassLoader loader, byte[] bytes) throws IOException {
         if (bytes == null) {
             return null;
-        } else {
-            try {
-                ObjectInputStream ois = new ObjectInputStreamEx(loader, new ByteArrayInputStream(bytes));
-                return ois.readObject();
-            } catch (IOException e) {
-                throw new IllegalArgumentException("Failed to deserialize object", e);
-            } catch (ClassNotFoundException e) {
-                throw new IllegalStateException("Failed to deserialize object type", e);
-            }
+        }
+        try {
+            ObjectInputStream ois = new SafeObjectInputStream(loader, classFilter, new ByteArrayInputStream(bytes));
+            return ois.readObject();
+        } catch (InvalidClassException e) {
+            throw e;
+        } catch (ClassNotFoundException e) {
+            throw new IOException("Failed to deserialize object type", e);
         }
     }
 }

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/main/java/org/noear/solon/serialization/javabin/SafeObjectInputStream.java
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/main/java/org/noear/solon/serialization/javabin/SafeObjectInputStream.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.serialization.javabin;
+
+import org.noear.solon.core.AppClassLoader;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectStreamClass;
+import java.lang.reflect.Proxy;
+
+/**
+ * 带类名白名单过滤的 ObjectInputStream。
+ *
+ * <p>同时覆盖 {@link #resolveClass(ObjectStreamClass)} 和
+ * {@link #resolveProxyClass(String[])}。
+ */
+public class SafeObjectInputStream extends ObjectInputStream {
+    private final ClassLoader loader;
+    private final JavabinClassFilter classFilter;
+
+    public SafeObjectInputStream(ClassLoader loader, JavabinClassFilter classFilter, InputStream in) throws IOException {
+        super(in);
+        if (loader == null) {
+            this.loader = AppClassLoader.global();
+        } else {
+            this.loader = loader;
+        }
+        if (classFilter == null) {
+            this.classFilter = new JavabinClassFilter();
+        } else {
+            this.classFilter = classFilter;
+        }
+    }
+
+    @Override
+    protected Class<?> resolveClass(ObjectStreamClass desc) throws IOException, ClassNotFoundException {
+        String name = desc.getName();
+        if (!classFilter.isAllowed(name)) {
+            throw new InvalidClassException(name,
+                    "class is not allowed by JavabinClassFilter; "
+                            + "if it is safe to deserialize, add an allow pattern "
+                            + "(e.g. JavabinSerializer#classFilter().allow(\"com.yourapp.\"))");
+        }
+        return Class.forName(name, false, loader);
+    }
+
+    @Override
+    protected Class<?> resolveProxyClass(String[] interfaces) throws IOException, ClassNotFoundException {
+        if (interfaces == null || interfaces.length == 0) {
+            throw new InvalidClassException("proxy",
+                    "dynamic proxy with empty interface list is not allowed");
+        }
+        Class<?>[] interfaceClasses = new Class<?>[interfaces.length];
+        for (int i = 0; i < interfaces.length; i++) {
+            String name = interfaces[i];
+            if (!classFilter.isAllowed(name)) {
+                throw new InvalidClassException(name,
+                        "proxy interface is not allowed by JavabinClassFilter");
+            }
+            interfaceClasses[i] = Class.forName(name, false, loader);
+        }
+        try {
+            return Proxy.getProxyClass(loader, interfaceClasses);
+        } catch (IllegalArgumentException e) {
+            throw new ClassNotFoundException("cannot create proxy class", e);
+        }
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/main/java/org/noear/solon/serialization/javabin/integration/SerializationJavabinPlugin.java
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/main/java/org/noear/solon/serialization/javabin/integration/SerializationJavabinPlugin.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.serialization.javabin.integration;
+
+import org.noear.solon.Solon;
+import org.noear.solon.Utils;
+import org.noear.solon.core.AppContext;
+import org.noear.solon.core.Plugin;
+import org.noear.solon.serialization.javabin.JavabinClassFilter;
+import org.noear.solon.serialization.javabin.JavabinSerializer;
+
+/**
+ * Javabin 序列化插件。
+ */
+public class SerializationJavabinPlugin implements Plugin {
+
+    static final String CFG_ALLOW = "solon.serialization.javabin.allow";
+    static final String CFG_DENY = "solon.serialization.javabin.deny";
+    static final String CFG_UNRESTRICTED = "solon.serialization.javabin.unrestricted";
+
+    @Override
+    public void start(AppContext context) {
+        applyConfig(JavabinSerializer.instance.classFilter());
+
+        JavabinSerializer serializer = JavabinSerializer.instance;
+        context.wrapAndPut(JavabinSerializer.class, serializer);
+        context.app().serializers().register("@type:java-bin", serializer);
+    }
+
+    static void applyConfig(JavabinClassFilter filter) {
+        String allow = Solon.cfg().get(CFG_ALLOW);
+        if (Utils.isNotEmpty(allow)) {
+            for (String s : allow.split(",")) {
+                filter.allow(s.trim());
+            }
+        }
+        String deny = Solon.cfg().get(CFG_DENY);
+        if (Utils.isNotEmpty(deny)) {
+            for (String s : deny.split(",")) {
+                filter.deny(s.trim());
+            }
+        }
+        if ("true".equalsIgnoreCase(Solon.cfg().get(CFG_UNRESTRICTED))) {
+            filter.allowAll(true);
+        }
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/main/resources/META-INF/solon/solon.serialization.javabin.properties
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/main/resources/META-INF/solon/solon.serialization.javabin.properties
@@ -1,0 +1,2 @@
+solon.plugin=org.noear.solon.serialization.javabin.integration.SerializationJavabinPlugin
+solon.plugin.priority=18

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/demo/DemoApp.java
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/demo/DemoApp.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package demo;
+
+import org.noear.solon.serialization.javabin.JavabinSerializer;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+public class DemoApp {
+    public static void main(String[] args) throws IOException {
+        JavabinSerializer serializer = new JavabinSerializer();
+        serializer.classFilter().allow("demo.");
+
+        String text = (String) serializer.deserialize(serializer.serialize("demo"), String.class);
+        User user = (User) serializer.deserialize(serializer.serialize(new User("solon")), User.class);
+
+        System.out.println(text);
+        System.out.println(user.name);
+    }
+
+    public static class User implements Serializable {
+        private final String name;
+
+        public User(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/features/serialization/javabin/ClassFilterTest.java
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/features/serialization/javabin/ClassFilterTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package features.serialization.javabin;
+
+import org.junit.jupiter.api.Test;
+import org.noear.solon.serialization.javabin.JavabinClassFilter;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ClassFilterTest {
+
+    @Test
+    public void defaultsAllowCommonJdk() {
+        JavabinClassFilter f = JavabinClassFilter.defaults();
+        assertTrue(f.isAllowed("java.lang.String"));
+        assertTrue(f.isAllowed("java.lang.Integer"));
+        assertTrue(f.isAllowed("java.util.ArrayList"));
+        assertTrue(f.isAllowed("java.util.HashMap"));
+        assertTrue(f.isAllowed("java.util.concurrent.ConcurrentHashMap"));
+        assertTrue(f.isAllowed("java.time.LocalDate"));
+        assertTrue(f.isAllowed("java.math.BigDecimal"));
+    }
+
+    @Test
+    public void defaultsDenyKnownGadgetRoots() {
+        JavabinClassFilter f = JavabinClassFilter.defaults();
+        assertFalse(f.isAllowed("java.lang.Runtime"));
+        assertFalse(f.isAllowed("java.lang.ProcessBuilder"));
+        assertFalse(f.isAllowed("javax.management.BadAttributeValueExpException"));
+        assertFalse(f.isAllowed("javax.naming.InitialContext"));
+        assertFalse(f.isAllowed("javax.script.ScriptEngineManager"));
+        assertFalse(f.isAllowed("com.sun.rowset.JdbcRowSetImpl"));
+        assertFalse(f.isAllowed("sun.reflect.annotation.AnnotationInvocationHandler"));
+    }
+
+    @Test
+    public void defaultsDenyCustomPojo() {
+        JavabinClassFilter f = JavabinClassFilter.defaults();
+        assertFalse(f.isAllowed("com.acme.Order"));
+    }
+
+    @Test
+    public void allowPackagePrefix() {
+        JavabinClassFilter f = new JavabinClassFilter();
+        f.allow("com.acme.");
+        assertTrue(f.isAllowed("com.acme.Order"));
+        assertTrue(f.isAllowed("com.acme.billing.Invoice"));
+        assertFalse(f.isAllowed("com.acmex.NotOurs"));
+    }
+
+    @Test
+    public void allowExactClassAndInnerClass() {
+        JavabinClassFilter f = new JavabinClassFilter();
+        f.allow("com.acme.Order");
+        assertTrue(f.isAllowed("com.acme.Order"));
+        assertTrue(f.isAllowed("com.acme.Order$Builder"));
+        assertFalse(f.isAllowed("com.acme.OrderAlike"));
+        assertFalse(f.isAllowed("com.acme.OtherOrder"));
+    }
+
+    @Test
+    public void denyBeatsAllow() {
+        JavabinClassFilter f = new JavabinClassFilter();
+        f.allow("com.acme.");
+        f.deny("com.acme.internal.");
+        assertTrue(f.isAllowed("com.acme.Order"));
+        assertFalse(f.isAllowed("com.acme.internal.Secret"));
+    }
+
+    @Test
+    public void unrestrictedAllowsAll() {
+        JavabinClassFilter f = JavabinClassFilter.unrestricted();
+        assertTrue(f.isAllowed("com.any.Class"));
+        assertTrue(f.isAllowed("java.lang.String"));
+    }
+
+    @Test
+    public void unrestrictedStillHonorsDeny() {
+        JavabinClassFilter f = JavabinClassFilter.unrestricted();
+        f.deny("com.acme.internal.");
+        assertTrue(f.isAllowed("com.any.Class"));
+        assertFalse(f.isAllowed("com.acme.internal.Secret"));
+    }
+
+    @Test
+    public void allowAllToggle() {
+        JavabinClassFilter f = new JavabinClassFilter();
+        assertFalse(f.isAllowed("com.acme.Any"));
+        f.allowAll(true);
+        assertTrue(f.isAllowed("com.acme.Any"));
+        f.allowAll(false);
+        assertFalse(f.isAllowed("com.acme.Any"));
+    }
+
+    @Test
+    public void arrayOfAllowedClassIsAllowed() {
+        JavabinClassFilter f = JavabinClassFilter.defaults();
+        assertTrue(f.isAllowed("[Ljava.lang.String;"));
+        assertTrue(f.isAllowed("[[Ljava.lang.String;"));
+    }
+
+    @Test
+    public void arrayOfDeniedClassIsDenied() {
+        JavabinClassFilter f = JavabinClassFilter.defaults();
+        assertFalse(f.isAllowed("[Ljava.lang.Runtime;"));
+    }
+
+    @Test
+    public void primitiveArraysAllowed() {
+        JavabinClassFilter f = new JavabinClassFilter();
+        assertTrue(f.isAllowed("[I"));
+        assertTrue(f.isAllowed("[B"));
+        assertTrue(f.isAllowed("[J"));
+    }
+
+    @Test
+    public void nullOrEmptyDenied() {
+        JavabinClassFilter f = JavabinClassFilter.defaults();
+        assertFalse(f.isAllowed(null));
+        assertFalse(f.isAllowed(""));
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/features/serialization/javabin/ProxyBypassTest.java
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/features/serialization/javabin/ProxyBypassTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package features.serialization.javabin;
+
+import org.junit.jupiter.api.Test;
+import org.noear.solon.serialization.javabin.JavabinSerializer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Base64;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * 动态代理绕过回归。
+ *
+ * <p>ysoserial 多条链以 {@link Proxy} + 恶意 {@code InvocationHandler}（典型如
+ * {@code AnnotationInvocationHandler}）起手；JVM 反序列化代理类时走
+ * {@code ObjectInputStream.resolveProxyClass(String[] interfaces)} 而不是
+ * {@code resolveClass}。如果过滤器只覆盖 {@code resolveClass}，这类 payload
+ * 会完全绕过名单。
+ *
+ * <p>本测试构造一个只暴露 {@link Map} 接口 + 恶意 handler 的代理对象，用旧的
+ * 只过 {@code resolveClass} 的实现会让 handler 的 {@code invoke} 被触发；新的
+ * {@link org.noear.solon.serialization.javabin.SafeObjectInputStream}
+ * 覆盖了 {@code resolveProxyClass}，所以 handler 永远不会被创建。
+ */
+public class ProxyBypassTest {
+
+    @Test
+    public void proxyHandlerDeniedByDefault() throws Exception {
+        MaliciousHandler.reset();
+
+        // 构造代理字节流：暴露 Map 接口（默认白名单里允许，不会触发 resolveClass 的拒绝）
+        // + 恶意 handler（Runtime-like payload 放 handler 里，触发则意味着 gadget 成功）
+        Map<?, ?> proxy = (Map<?, ?>) Proxy.newProxyInstance(
+                ProxyBypassTest.class.getClassLoader(),
+                new Class<?>[]{Map.class},
+                new MaliciousHandler());
+
+        String encoded = encodeRawJava((Serializable) proxy);
+
+        JavabinSerializer ser = new JavabinSerializer();
+        // 代理类反序列化必须在 resolveProxyClass 阶段被拒掉，handler 绝对不能创建
+        assertThrows(InvalidClassException.class,
+                () -> ser.deserialize(encoded, Map.class));
+
+        assertFalse(MaliciousHandler.INVOKED.get(),
+                "MaliciousHandler.invoke 不应被触发——resolveProxyClass 阶段就应该被拒");
+    }
+
+    @Test
+    public void proxyInterfaceNotInAllowListDenied() throws Exception {
+        MaliciousHandler.reset();
+
+        // 自定义接口，不在白名单里
+        Runnable proxy = (Runnable) Proxy.newProxyInstance(
+                ProxyBypassTest.class.getClassLoader(),
+                new Class<?>[]{Runnable.class},
+                new MaliciousHandler());
+
+        String encoded = encodeRawJava((Serializable) proxy);
+
+        JavabinSerializer ser = new JavabinSerializer();
+        // Runnable 在 java.lang，默认是允许的；但若我们再包一层拒绝 Runnable，
+        // 就能验证 proxy 的每个 interface 都会被过滤
+        ser.classFilter().deny("java.lang.Runnable");
+
+        assertThrows(InvalidClassException.class,
+                () -> ser.deserialize(encoded, Object.class));
+        assertFalse(MaliciousHandler.INVOKED.get());
+    }
+
+    private static String encodeRawJava(Serializable value) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(value);
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    /**
+     * 模拟恶意 handler：如果 readObject 被执行到这里就意味着 gadget 成功。
+     * 真实利用中这里会是 AnnotationInvocationHandler / TemplatesImpl 等。
+     */
+    public static final class MaliciousHandler implements InvocationHandler, Serializable {
+        private static final long serialVersionUID = 1L;
+        static final java.util.concurrent.atomic.AtomicBoolean INVOKED =
+                new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        static void reset() { INVOKED.set(false); }
+
+        @Override
+        public Object invoke(Object proxy, Method method, Object[] args) {
+            INVOKED.set(true);
+            return null;
+        }
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/features/serialization/javabin/RoundTripTest.java
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/features/serialization/javabin/RoundTripTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package features.serialization.javabin;
+
+import features.serialization.javabin.model.UserDo;
+import org.junit.jupiter.api.Test;
+import org.noear.solon.serialization.javabin.JavabinSerializer;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * JavabinSerializer 基础往返测试：默认允许的 JDK 类型能正常序列化/反序列化。
+ */
+public class RoundTripTest {
+
+    @Test
+    public void roundTripString() throws IOException {
+        JavabinSerializer ser = new JavabinSerializer();
+        String encoded = ser.serialize("hello");
+        Object decoded = ser.deserialize(encoded, String.class);
+        assertEquals("hello", decoded);
+    }
+
+    @Test
+    public void roundTripList() throws IOException {
+        JavabinSerializer ser = new JavabinSerializer();
+        List<String> src = new ArrayList<>(Arrays.asList("a", "b", "c"));
+        String encoded = ser.serialize(src);
+        Object decoded = ser.deserialize(encoded, List.class);
+        assertEquals(src, decoded);
+    }
+
+    @Test
+    public void roundTripMap() throws IOException {
+        JavabinSerializer ser = new JavabinSerializer();
+        Map<String, Integer> src = new HashMap<>();
+        src.put("x", 1);
+        src.put("y", 2);
+        String encoded = ser.serialize(src);
+        Object decoded = ser.deserialize(encoded, Map.class);
+        assertEquals(src, decoded);
+    }
+
+    @Test
+    public void roundTripCustomPojoAfterAllow() throws IOException {
+        JavabinSerializer ser = new JavabinSerializer();
+        ser.classFilter().allow("features.serialization.javabin.model.");
+
+        UserDo src = new UserDo("Jerry", 30);
+        String encoded = ser.serialize(src);
+        Object decoded = ser.deserialize(encoded, UserDo.class);
+        assertEquals(src, decoded);
+    }
+
+    @Test
+    public void nullInputsRoundTrip() throws IOException {
+        JavabinSerializer ser = new JavabinSerializer();
+        assertNull(ser.serialize(null));
+        assertNull(ser.deserialize(null, String.class));
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/features/serialization/javabin/UnsafeClassDeniedTest.java
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/features/serialization/javabin/UnsafeClassDeniedTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package features.serialization.javabin;
+
+import features.serialization.javabin.model.UserDo;
+import org.junit.jupiter.api.Test;
+import org.noear.solon.serialization.javabin.JavabinClassFilter;
+import org.noear.solon.serialization.javabin.JavabinSerializer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Base64;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * 安全性回归测试：
+ *
+ * <ul>
+ *   <li>默认过滤器下，非白名单的 POJO 类会在 {@code readObject} 之前被
+ *       {@link InvalidClassException} 拒绝——这是本次修复的关键断言</li>
+ *   <li>即使声明类型是 {@code String.class}，也不会绕过过滤器先反序列化</li>
+ *   <li>{@link JavabinClassFilter#unrestricted()} 兼容旧行为</li>
+ * </ul>
+ */
+public class UnsafeClassDeniedTest {
+
+    @Test
+    public void probePayloadRejectedBeforeReadObject() throws Exception {
+        ProbePayload.reset();
+
+        JavabinSerializer ser = new JavabinSerializer();
+        String encoded = encodeRawJava(new ProbePayload("attacker-controlled bytes"));
+
+        assertThrows(InvalidClassException.class,
+                () -> ser.deserialize(encoded, Object.class));
+
+        assertFalse(ProbePayload.READ_OBJECT_CALLED.get(),
+                "readObject 应该在反序列化前就被过滤掉");
+    }
+
+    @Test
+    public void declaredTypeStringDoesNotBypassFilter() throws Exception {
+        ProbePayload.reset();
+
+        JavabinSerializer ser = new JavabinSerializer();
+        String encoded = encodeRawJava(new ProbePayload("attacker-controlled bytes"));
+
+        // 老版本会先反序列化、再抛 ClassCastException；新版本应该在反序列化之前
+        // 就抛 InvalidClassException
+        assertThrows(InvalidClassException.class,
+                () -> ser.deserialize(encoded, String.class));
+        assertFalse(ProbePayload.READ_OBJECT_CALLED.get(),
+                "String.class 不应该绕开过滤器");
+    }
+
+    @Test
+    public void allowedCustomClassStillWorks() throws Exception {
+        JavabinSerializer ser = new JavabinSerializer();
+        ser.classFilter().allow("features.serialization.javabin.model.");
+
+        UserDo src = new UserDo("Jerry", 30);
+        String encoded = ser.serialize(src);
+        Object decoded = ser.deserialize(encoded, UserDo.class);
+        assertTrue(decoded instanceof UserDo);
+    }
+
+    @Test
+    public void unrestrictedFilterAllowsEverything() throws Exception {
+        ProbePayload.reset();
+
+        JavabinSerializer ser = new JavabinSerializer(JavabinClassFilter.unrestricted());
+        String encoded = encodeRawJava(new ProbePayload("attacker-controlled bytes"));
+
+        Object decoded = ser.deserialize(encoded, Object.class);
+        assertTrue(decoded instanceof ProbePayload);
+        assertTrue(ProbePayload.READ_OBJECT_CALLED.get());
+    }
+
+    @Test
+    public void knownGadgetRootsDenied() {
+        JavabinClassFilter filter = JavabinClassFilter.defaults();
+        assertFalse(filter.isAllowed("java.lang.Runtime"));
+        assertFalse(filter.isAllowed("javax.management.BadAttributeValueExpException"));
+        assertFalse(filter.isAllowed("javax.naming.InitialContext"));
+        assertFalse(filter.isAllowed("com.sun.rowset.JdbcRowSetImpl"));
+    }
+
+    private static String encodeRawJava(Serializable value) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ObjectOutputStream oos = new ObjectOutputStream(baos)) {
+            oos.writeObject(value);
+        }
+        return Base64.getEncoder().encodeToString(baos.toByteArray());
+    }
+
+    /**
+     * 探针：用 readObject side effect 来观察反序列化是否真的发生了。
+     * 真实攻击里这里会是 ysoserial 的 gadget 链。
+     */
+    static final class ProbePayload implements Serializable {
+        private static final long serialVersionUID = 1L;
+        static final AtomicBoolean READ_OBJECT_CALLED = new AtomicBoolean(false);
+
+        String note;
+
+        ProbePayload(String note) { this.note = note; }
+
+        static void reset() { READ_OBJECT_CALLED.set(false); }
+
+        private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
+            in.defaultReadObject();
+            READ_OBJECT_CALLED.set(true);
+        }
+    }
+}

--- a/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/features/serialization/javabin/model/UserDo.java
+++ b/solon-projects/solon-serialization/solon-serialization-javabin/src/test/java/features/serialization/javabin/model/UserDo.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package features.serialization.javabin.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class UserDo implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private String name;
+    private int age;
+
+    public UserDo() {
+    }
+
+    public UserDo(String name, int age) {
+        this.name = name;
+        this.age = age;
+    }
+
+    public String getName() { return name; }
+    public void setName(String name) { this.name = name; }
+    public int getAge() { return age; }
+    public void setAge(int age) { this.age = age; }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserDo)) return false;
+        UserDo userDo = (UserDo) o;
+        return age == userDo.age && Objects.equals(name, userDo.name);
+    }
+
+    @Override
+    public int hashCode() { return Objects.hash(name, age); }
+}

--- a/solon-projects/solon-web/solon-sessionstate-jedis/src/main/java/org/noear/solon/sessionstate/jedis/JavabinSerializer.java
+++ b/solon-projects/solon-web/solon-sessionstate-jedis/src/main/java/org/noear/solon/sessionstate/jedis/JavabinSerializer.java
@@ -23,11 +23,18 @@ import java.lang.reflect.Type;
 import java.util.Base64;
 
 /**
- * Javabin 序列化实现
+ * Javabin 序列化实现。
  *
  * @author noear
  * @since 1.5
+ * @deprecated since 3.11 -- 此实现未对反序列化类做白名单过滤（CWE-502）。
+ * 请改用 {@code solon-serialization-javabin} 模块下的
+ * {@code org.noear.solon.serialization.javabin.JavabinSerializer}；
+ * 它默认按 {@code JavabinClassFilter.defaults()} 过滤，可通过
+ * {@code classFilter().allow(...)} 放宽，并且覆盖了 {@code resolveProxyClass}
+ * 防止动态代理绕过。
  */
+@Deprecated
 public class JavabinSerializer implements Serializer<String> {
     public static final JavabinSerializer instance = new JavabinSerializer();
 

--- a/solon-projects/solon-web/solon-sessionstate-jedis/src/main/java/org/noear/solon/sessionstate/jedis/JedisSessionState.java
+++ b/solon-projects/solon-web/solon-sessionstate-jedis/src/main/java/org/noear/solon/sessionstate/jedis/JedisSessionState.java
@@ -35,7 +35,8 @@ public class JedisSessionState extends SessionStateBase {
 
     protected JedisSessionState(Context ctx) {
         super(ctx);
-        this.serializer = JavabinSerializer.instance;
+        Serializer<String> configuredSerializer = JedisSessionStateFactory.getInstance().serializer();
+        this.serializer = (configuredSerializer != null ? configuredSerializer : JavabinSerializer.instance);
         this.redisClient = JedisSessionStateFactory.getInstance().redisClient();
     }
 

--- a/solon-projects/solon-web/solon-sessionstate-jedis/src/main/java/org/noear/solon/sessionstate/jedis/JedisSessionStateFactory.java
+++ b/solon-projects/solon-web/solon-sessionstate-jedis/src/main/java/org/noear/solon/sessionstate/jedis/JedisSessionStateFactory.java
@@ -20,6 +20,7 @@ import org.noear.solon.Solon;
 import org.noear.solon.core.handle.Context;
 import org.noear.solon.core.handle.SessionState;
 import org.noear.solon.core.handle.SessionStateFactory;
+import org.noear.solon.core.serialize.Serializer;
 
 import java.util.Properties;
 
@@ -48,9 +49,22 @@ public class JedisSessionStateFactory implements SessionStateFactory {
     }
 
     private RedisClient redisClient;
+    private Serializer<String> serializer;
 
     public RedisClient redisClient() {
         return redisClient;
+    }
+
+    /**
+     * 自定义 session 序列化器。
+     */
+    public JedisSessionStateFactory serializer(Serializer<String> serializer) {
+        this.serializer = serializer;
+        return this;
+    }
+
+    public Serializer<String> serializer() {
+        return serializer;
     }
 
     public static final int SESSION_STATE_PRIORITY = 2;

--- a/solon-projects/solon-web/solon-sessionstate-jedis/src/main/java/org/noear/solon/sessionstate/jedis/ObjectInputStreamEx.java
+++ b/solon-projects/solon-web/solon-sessionstate-jedis/src/main/java/org/noear/solon/sessionstate/jedis/ObjectInputStreamEx.java
@@ -23,11 +23,15 @@ import java.io.ObjectInputStream;
 import java.io.ObjectStreamClass;
 
 /**
- * ObjectInputStream 增加类加载控制
+ * ObjectInputStream 增加类加载控制。
  *
  * @author noear
  * @since 2.8
+ * @deprecated since 3.11 -- 仅做 classloader 切换，不做类白名单过滤。
+ * 请改用 {@code solon-serialization-javabin} 模块下的
+ * {@code org.noear.solon.serialization.javabin.SafeObjectInputStream}。
  */
+@Deprecated
 public class ObjectInputStreamEx extends ObjectInputStream {
     private ClassLoader loader;
 


### PR DESCRIPTION
### 这个PR有什么用 / 我们为什么需要它？

对应 #421。

为 javabin 反序列化补一个可显式接入的安全实现，并给 cache/session 场景补上配置与注入入口。
当前 `solon-cache-jedis` / `solon-sessionstate-jedis` 使用的 `JavabinSerializer` 在
`ObjectInputStreamEx` 中只做类加载，不做类过滤；后端字节一旦可被污染，读取时就会进入
无约束的 Java 原生反序列化。

这次先提供安全实现和迁移路径，默认行为继续保持兼容；默认切换可以后续再评估。

### 总结您的更改

- 新增 `solon-serialization-javabin` 模块，提供：
  - `JavabinClassFilter`
  - `SafeObjectInputStream`
  - 新模块下的 `JavabinSerializer`
  - `SerializationJavabinPlugin`
- `SafeObjectInputStream` 同时覆盖 `resolveClass` 和 `resolveProxyClass`
- `JedisSessionStateFactory` 增加 `serializer(Serializer<String>)` / `serializer()`
- `JedisSessionState` 优先使用显式注入的 serializer；未设置时继续沿用原默认实现
- 老的 `JavabinSerializer` / `ObjectInputStreamEx` 保留原行为，并标记为 `@Deprecated`
- 新增 `src/test/java/demo/DemoApp.java`
- 新增 `src/test/java/features/...` 测试，覆盖 round-trip、默认拒绝、proxy 绕过回归和过滤规则匹配


也可以先按兼容模式接入：

```properties
solon.serialization.javabin.allow=com.yourapp.,com.other.lib.
solon.serialization.javabin.deny=com.yourapp.internal.
solon.serialization.javabin.unrestricted=true
```

验证

```bash
mvn -pl solon-projects/solon-serialization/solon-serialization-javabin test -DskipITs
mvn -pl solon-projects/solon-web/solon-sessionstate-jedis -am -DskipTests compile
mvn -pl solon-projects/solon-data/solon-cache-jedis,solon-projects/solon-web/solon-sessionstate-jedis -am -DskipTests compile
```


#### 请注明您已完成以下工作：

- [x] 确保测试通过，并在需要时添加测试覆盖率。
- [x] 确保提交消息遵循仓库现有提交前缀规范。
- [x] 考虑文档的影响，如果需要，打开一个新的文档问题或文档更改的PR。