### PR TITLE
修复 solon-sessionstate-jwt JWT 默认密钥硬编码问题

### DIFF
--- a/solon-projects/solon-web/solon-sessionstate-jwt/README.md
+++ b/solon-projects/solon-web/solon-sessionstate-jwt/README.md
@@ -7,7 +7,7 @@ server.session:
   state:
     jwt:
       name: TOKEN #变量名；（可不配，默认：TOKEN）
-      secret: "E3F9N2kRDQf55pnJPnFoo5+ylKmZQ7AXmWeOVPKbEd8=" #密钥（使用 JwtUtils.createKey() 生成）；（可不配，默认：xxx）
+      #secret: "your-base64-secret" #密钥（使用 JwtUtils.createKey() 生成）；（可不配，默认保存到运行 Solon 进程的操作系统用户 home 目录下的 ~/.solon/settings.json）
       prefix: Bearer #令牌前缀（可不配，默认：空）
       allowExpire: true #充许超时；（可不配，默认：true）；false，则token一直有效
       allowAutoIssue: true #充许自动输出；（可不配，默认：true）；flase，则不向header 或 cookie 设置值（由用户手动控制）
@@ -24,3 +24,13 @@ public class JwtTest {
     }
 }
 ```
+
+如果不配置 `server.session.state.jwt.secret`，Solon 会首次启动时生成随机密钥，并将其保存到运行 Solon 进程的操作系统用户 home 目录下的 `~/.solon/settings.json`。该文件使用 Map 结构保存设置，例如：
+
+```json
+{
+  "server.session.state.jwt.secret": "generated-secret"
+}
+```
+
+后续启动会复用已保存的密钥；显式配置的 `server.session.state.jwt.secret` 优先级更高。

--- a/solon-projects/solon-web/solon-sessionstate-jwt/src/main/java/org/noear/solon/sessionstate/jwt/JwtSecretStore.java
+++ b/solon-projects/solon-web/solon-sessionstate-jwt/src/main/java/org/noear/solon/sessionstate/jwt/JwtSecretStore.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2017-2025 noear.org and authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.noear.solon.sessionstate.jwt;
+
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.noear.snack4.ONode;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.channels.FileChannel;
+import java.nio.channels.FileLock;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Stores generated default secrets in the Solon settings file under the home
+ * directory of the operating-system user running the Solon process.
+ *
+ * <p>The file is intentionally a top-level map so other Solon defaults can be
+ * added later without changing this storage format.</p>
+ */
+final class JwtSecretStore {
+    static final String SETTINGS_KEY = "server.session.state.jwt.secret";
+
+    private static final String SETTINGS_DIR = ".solon";
+    private static final String SETTINGS_FILE = "settings.json";
+    private static final ReentrantLock LOCAL_LOCK = new ReentrantLock();
+
+    private JwtSecretStore() {
+    }
+
+    static String loadOrCreate() {
+        String userHome = System.getProperty("user.home");
+        if (userHome == null || userHome.trim().length() == 0) {
+            throw new IllegalStateException("Unable to resolve the user home directory for the JWT secret");
+        }
+
+        return loadOrCreate(Paths.get(userHome, SETTINGS_DIR, SETTINGS_FILE));
+    }
+
+    static String loadOrCreate(Path settingsFile) {
+        Path target = settingsFile.toAbsolutePath();
+        Path parent = target.getParent();
+        if (parent == null) {
+            throw new IllegalStateException("Unable to resolve the settings directory for the JWT secret");
+        }
+
+        LOCAL_LOCK.lock();
+        try {
+            Files.createDirectories(parent);
+            setPrivatePermissions(parent, true);
+
+            Path lockFile = target.resolveSibling(target.getFileName().toString() + ".lock");
+            try (FileChannel channel = FileChannel.open(lockFile,
+                    StandardOpenOption.CREATE, StandardOpenOption.WRITE);
+                 FileLock ignored = channel.lock()) {
+                Map<String, Object> settings = readSettings(target);
+                String configuredSecret = readSecret(settings);
+                if (configuredSecret != null) {
+                    return configuredSecret;
+                }
+
+                String generatedSecret = JwtUtils.createKey();
+                settings.put(SETTINGS_KEY, generatedSecret);
+                writeSettings(target, parent, settings);
+                return generatedSecret;
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Unable to load or persist the JWT secret at " + target, e);
+        } finally {
+            LOCAL_LOCK.unlock();
+        }
+    }
+
+    private static Map<String, Object> readSettings(Path target) throws IOException {
+        if (!Files.exists(target)) {
+            return new LinkedHashMap<>();
+        }
+        if (!Files.isRegularFile(target)) {
+            throw new IllegalStateException("JWT settings path is not a regular file: " + target);
+        }
+        // Protect an existing settings file before reading its persisted secret.
+        setPrivatePermissions(target, false);
+
+        String json = new String(Files.readAllBytes(target), StandardCharsets.UTF_8).trim();
+        if (json.length() == 0) {
+            return new LinkedHashMap<>();
+        }
+
+        final Object decoded;
+        try {
+            decoded = ONode.deserialize(json, Map.class);
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Unable to parse Solon settings JSON: " + target, e);
+        }
+
+        if (!(decoded instanceof Map)) {
+            throw new IllegalStateException("Solon settings JSON must contain a top-level object: " + target);
+        }
+
+        Map<String, Object> settings = new LinkedHashMap<>();
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) decoded).entrySet()) {
+            if (!(entry.getKey() instanceof String)) {
+                throw new IllegalStateException("Solon settings JSON contains a non-string key: " + target);
+            }
+            settings.put((String) entry.getKey(), entry.getValue());
+        }
+        return settings;
+    }
+
+    private static String readSecret(Map<String, Object> settings) {
+        Object value = settings.get(SETTINGS_KEY);
+        if (value == null) {
+            return null;
+        }
+        if (!(value instanceof String)) {
+            throw new IllegalStateException("Solon setting '" + SETTINGS_KEY + "' must be a string");
+        }
+
+        String secret = (String) value;
+        if (secret.trim().length() == 0) {
+            throw new IllegalStateException("Solon setting '" + SETTINGS_KEY + "' must not be empty");
+        }
+
+        try {
+            Keys.hmacShaKeyFor(Decoders.BASE64.decode(secret));
+        } catch (RuntimeException e) {
+            throw new IllegalStateException("Solon setting '" + SETTINGS_KEY + "' must be a valid Base64 HMAC key");
+        }
+        return secret;
+    }
+
+    private static void writeSettings(Path target, Path parent, Map<String, Object> settings) throws IOException {
+        byte[] content = ONode.serialize(settings).getBytes(StandardCharsets.UTF_8);
+        Path temporary = Files.createTempFile(parent, ".settings-", ".tmp");
+        try {
+            Files.write(temporary, content, StandardOpenOption.WRITE);
+            setPrivatePermissions(temporary, false);
+            try {
+                Files.move(temporary, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            } catch (AtomicMoveNotSupportedException e) {
+                Files.move(temporary, target, StandardCopyOption.REPLACE_EXISTING);
+            }
+            setPrivatePermissions(target, false);
+        } finally {
+            Files.deleteIfExists(temporary);
+        }
+    }
+
+    private static void setPrivatePermissions(Path path, boolean directory) throws IOException {
+        try {
+            Set<PosixFilePermission> permissions = PosixFilePermissions.fromString(directory ? "rwx------" : "rw-------");
+            Files.setPosixFilePermissions(path, permissions);
+        } catch (UnsupportedOperationException ignored) {
+            // Non-POSIX filesystems use their platform's normal permission model.
+        }
+    }
+}

--- a/solon-projects/solon-web/solon-sessionstate-jwt/src/main/java/org/noear/solon/sessionstate/jwt/JwtSessionStateFactory.java
+++ b/solon-projects/solon-web/solon-sessionstate-jwt/src/main/java/org/noear/solon/sessionstate/jwt/JwtSessionStateFactory.java
@@ -39,11 +39,12 @@ public class JwtSessionStateFactory implements SessionStateFactory {
         String signKey0 = JwtSessionProps.getInstance().secret;
         if (Utils.isNotEmpty(signKey0)) {
             signKey = signKey0;
+        } else {
+            signKey = JwtSecretStore.loadOrCreate();
         }
     }
 
-
-    private String signKey = "DHPjbM5QczZ2cysd4gpDbG/4SnuwzWX3sA1i6AXiAbo=";
+    private String signKey;
 
     /**
      * 获取签名Key

--- a/solon-projects/solon-web/solon-sessionstate-jwt/src/main/java/org/noear/solon/sessionstate/jwt/JwtUtils.java
+++ b/solon-projects/solon-web/solon-sessionstate-jwt/src/main/java/org/noear/solon/sessionstate/jwt/JwtUtils.java
@@ -135,7 +135,8 @@ public class JwtUtils {
         } catch (ExpiredJwtException ex) {
 
         } catch (Throwable e) {
-            log.warn(e.getMessage(), e);
+            // Do not write attacker-controlled JWT contents to the application log.
+            log.debug("JWT validation failed: " + e.getClass().getSimpleName());
         }
 
         return null;

--- a/solon-projects/solon-web/solon-sessionstate-jwt/src/test/java/features/sessionstate/jwt/StateTest.java
+++ b/solon-projects/solon-web/solon-sessionstate-jwt/src/test/java/features/sessionstate/jwt/StateTest.java
@@ -9,7 +9,7 @@ import org.noear.solon.test.SolonTest;
  * @author noear 2024/11/29 created
  */
 
-@SolonTest(App.class)
+@SolonTest(value = App.class, properties = {"user.home=target/test-home"})
 public class StateTest extends HttpTester {
     @Test
     public void test() throws Exception {

--- a/solon-projects/solon-web/solon-sessionstate-jwt/src/test/java/org/noear/solon/sessionstate/jwt/JwtSecretStoreTest.java
+++ b/solon-projects/solon-web/solon-sessionstate-jwt/src/test/java/org/noear/solon/sessionstate/jwt/JwtSecretStoreTest.java
@@ -1,0 +1,112 @@
+package org.noear.solon.sessionstate.jwt;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.noear.snack4.ONode;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JwtSecretStoreTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    public void createsReusesAndPreservesMapEntries() throws Exception {
+        Path settingsFile = tempDir.resolve(".solon/settings.json");
+
+        String firstSecret = JwtSecretStore.loadOrCreate(settingsFile);
+        assertFalse(firstSecret.trim().isEmpty());
+
+        Map<?, ?> firstSettings = readSettings(settingsFile);
+        assertEquals(firstSecret, firstSettings.get(JwtSecretStore.SETTINGS_KEY));
+
+        Map<String, Object> settingsWithFutureValue = new LinkedHashMap<>();
+        settingsWithFutureValue.put("future.setting", "preserved");
+        settingsWithFutureValue.put(JwtSecretStore.SETTINGS_KEY, firstSecret);
+        Files.write(settingsFile,
+                ONode.serialize(settingsWithFutureValue).getBytes(StandardCharsets.UTF_8));
+
+        String secondSecret = JwtSecretStore.loadOrCreate(settingsFile);
+        assertEquals(firstSecret, secondSecret);
+
+        Map<?, ?> secondSettings = readSettings(settingsFile);
+        assertEquals("preserved", secondSettings.get("future.setting"));
+        assertEquals(firstSecret, secondSettings.get(JwtSecretStore.SETTINGS_KEY));
+    }
+
+    @Test
+    public void rejectsMalformedSettingsInsteadOfRegeneratingSecret() throws Exception {
+        Path settingsFile = tempDir.resolve(".solon/settings.json");
+        Files.createDirectories(settingsFile.getParent());
+        Files.write(settingsFile, "{not-json}".getBytes(StandardCharsets.UTF_8));
+
+        assertThrows(IllegalStateException.class, () -> JwtSecretStore.loadOrCreate(settingsFile));
+    }
+
+    @Test
+    public void rejectsInvalidPersistedSecret() throws Exception {
+        Path settingsFile = tempDir.resolve(".solon/settings.json");
+        writeSettings(settingsFile, "not-base64");
+
+        assertThrows(IllegalStateException.class, () -> JwtSecretStore.loadOrCreate(settingsFile));
+    }
+
+    @Test
+    public void tightensPermissionsOnExistingSettingsFile() throws Exception {
+        Path settingsFile = tempDir.resolve(".solon/settings.json");
+        writeSettings(settingsFile, JwtUtils.createKey());
+
+        try {
+            Files.setPosixFilePermissions(settingsFile,
+                    PosixFilePermissions.fromString("rw-r--r--"));
+            JwtSecretStore.loadOrCreate(settingsFile);
+
+            Set<PosixFilePermission> permissions = Files.getPosixFilePermissions(settingsFile);
+            assertEquals(PosixFilePermissions.fromString("rw-------"), permissions);
+        } catch (UnsupportedOperationException ignored) {
+            // The permission assertion is only applicable to POSIX filesystems.
+        }
+    }
+
+    @Test
+    public void usesSolonSettingsUnderUserHome() throws Exception {
+        String previousUserHome = System.getProperty("user.home");
+        try {
+            System.setProperty("user.home", tempDir.toString());
+            String secret = JwtSecretStore.loadOrCreate();
+            Path settingsFile = tempDir.resolve(".solon/settings.json");
+
+            assertEquals(secret, readSettings(settingsFile).get(JwtSecretStore.SETTINGS_KEY));
+        } finally {
+            if (previousUserHome == null) {
+                System.clearProperty("user.home");
+            } else {
+                System.setProperty("user.home", previousUserHome);
+            }
+        }
+    }
+
+    private Map<?, ?> readSettings(Path settingsFile) throws Exception {
+        String json = new String(Files.readAllBytes(settingsFile), StandardCharsets.UTF_8);
+        return ONode.deserialize(json, Map.class);
+    }
+
+    private void writeSettings(Path settingsFile, String secret) throws Exception {
+        Files.createDirectories(settingsFile.getParent());
+        Map<String, Object> settings = new LinkedHashMap<>();
+        settings.put(JwtSecretStore.SETTINGS_KEY, secret);
+        Files.write(settingsFile,
+                ONode.serialize(settings).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/solon-projects/solon-web/solon-sessionstate-jwt/src/test/resources/app.yml
+++ b/solon-projects/solon-web/solon-sessionstate-jwt/src/test/resources/app.yml
@@ -1,7 +1,6 @@
 #Jwt 令牌变量名；（可不配，默认：TOKEN）
 server.session.state.jwt.name: "TOKEN"
-#Jwt 密钥（使用 JwtUtils.createKey() 生成）；（可不配，默认：xxx）
-server.session.state.jwt.secret: "E3F9N2kRDQf55pnJPnFoo5+ylKmZQ7AXmWeOVPKbEd8="
+#Jwt 密钥；（可不配，默认自动生成并保存到运行 Solon 进程的操作系统用户 home 目录下的 ~/.solon/settings.json）
 #Jwt 充许使用Header传递；（可不配，默认：使用 Cookie 传递）；true，则使用 header 传递
 server.session.state.jwt.allowUseHeader: false
 server.session.state.jwt.allowAutoIssue: true


### PR DESCRIPTION
Fixes #429

## 问题

当用户没有配置 `server.session.state.jwt.secret` 时，`solon-sessionstate-jwt` 会使用源码中的固定 JWT 签名密钥。

该密钥可以从公开源码中获得，导致默认配置下签发的 JWT 存在被伪造的风险。

## 修改内容

- 移除源码中的固定默认 JWT 密钥。
- 保留 `server.session.state.jwt.secret` 的显式配置行为。
- 未配置密钥时，首次启动自动生成随机 HS256 密钥。
- 将生成的密钥保存到运行 Solon 进程的操作系统用户 home 目录下的 `~/.solon/settings.json`。
- 使用顶层 Map 结构保存设置，并保留已有配置项。
- 使用文件锁避免多个进程同时首次启动时生成不同密钥。
- 使用临时文件和原子替换方式写入配置。
- 在 Unix 系统下限制配置目录和配置文件权限。
- 读取已有配置时重新检查并收紧配置文件权限。
- 校验保存的密钥是否为合法且长度足够的 Base64 HMAC 密钥。
- JWT 校验失败时不再将攻击者提交的 Token 内容写入日志。
- 移除测试配置中的固定密钥。

## 默认行为

如果用户显式配置：

```yaml
server.session.state.jwt.secret: "your-base64-secret"
```

则继续使用用户配置的密钥。

如果用户没有配置该属性，Solon 会首次生成随机密钥，并保存到当前运行进程所属操作系统用户 home 目录下的 `~/.solon/settings.json`。

文件内容使用 Map 结构，例如：

```json
{
  "server.session.state.jwt.secret": "generated-secret"
}
```

后续启动会继续复用该密钥。

## 对现有配置的影响

显式配置了 `server.session.state.jwt.secret` 的应用不受本次默认密钥逻辑影响。

未配置密钥、依赖旧版本固定默认密钥的应用升级后会生成新的密钥，因此旧版本签发的 JWT 可能失效。

需要保持 Token 连续性的应用，应在升级前配置一个由应用自身安全管理的密钥。

生成的 `~/.solon/settings.json` 不应提交到源码仓库。

## 测试

执行：

```bash
mvn -pl solon-projects/solon-web/solon-sessionstate-jwt test
```

测试结果：

```text
Tests run: 6
Failures: 0
BUILD SUCCESS
```