### PR TITLE
fix: path traversal detect in realPath

### DIFF
--- a/solon-projects/solon-web/solon-web-webdav/src/main/java/org/noear/solon/web/webdav/impl/LocalFileSystem.java
+++ b/solon-projects/solon-web/solon-web-webdav/src/main/java/org/noear/solon/web/webdav/impl/LocalFileSystem.java
@@ -24,6 +24,7 @@ import org.noear.solon.web.webdav.FileInfo;
 import org.noear.solon.web.webdav.FileSystem;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Date;
@@ -48,7 +49,17 @@ public class LocalFileSystem implements FileSystem {
         if (StrUtil.isBlank(path)) {
             return rootPath;
         }
-        return rootPath + "/" + path;
+        try {
+            File rootDir = new File(rootPath).getCanonicalFile();
+            File resolved = new File(rootDir, path).getCanonicalFile();
+            if (!resolved.getCanonicalPath().startsWith(rootDir.getCanonicalPath() + File.separator)
+                && !resolved.getCanonicalPath().equals(rootDir.getCanonicalPath())) {
+                throw new SecurityException("Path traversal detected: " + path);
+            }
+            return resolved.getPath();
+        } catch (IOException e) {
+            throw new SecurityException("Invalid path: " + path, e);
+        }
     }
 
     private FileInfo file2Info(File file) {


### PR DESCRIPTION
Bare rootPath + "/" + path concatenation allows ../ and symlink escapes, enabling arbitrary file read/write/delete via WebDAV.

Replace with getCanonicalFile() + boundary check.

#### 请注明您已完成以下工作：

- [ ✅ ] 确保测试通过，并在需要时添加测试覆盖率。
- [ ✅ ] 确保提交消息遵循 [常规提交规范](https://www.conventionalcommits.org/) 的规则。
- [ ✅ ] 考虑文档的影响，如果需要，打开一个新的文档问题或文档更改的PR。