### PR TITLE
fix(maven-plugin): close all pooled RandomAccessFiles in FilePool.close

### DIFF
--- a/solon-projects/solon-tool/solon-maven-plugin/src/main/java/org/noear/solon/maven/plugin/tools/data/RandomAccessDataFile.java
+++ b/solon-projects/solon-tool/solon-maven-plugin/src/main/java/org/noear/solon/maven/plugin/tools/data/RandomAccessDataFile.java
@@ -262,15 +262,29 @@ public class RandomAccessDataFile implements RandomAccessData {
 
 		public void close() throws IOException {
 			this.available.acquireUninterruptibly(this.size);
+			IOException first = null;
 			try {
 				RandomAccessFile pooledFile = this.files.poll();
 				while (pooledFile != null) {
-					pooledFile.close();
+					try {
+						pooledFile.close();
+					}
+					catch (IOException e) {
+						if (first == null) {
+							first = e;
+						}
+						else {
+							first.addSuppressed(e);
+						}
+					}
 					pooledFile = this.files.poll();
 				}
 			}
 			finally {
 				this.available.release(this.size);
+			}
+			if (first != null) {
+				throw first;
 			}
 		}
 


### PR DESCRIPTION

### Problem

`RandomAccessDataFile.FilePool#close()` closes each pooled `java.io.RandomAccessFile` in a loop. If one `close()` call throws an `IOException`, the loop stops right there and the remaining pooled files are never closed, so they leak.

### Solution

Wrap each `RandomAccessFile#close()` call in a try/catch, keep draining the queue after a failure instead of stopping, and rethrow the first `IOException` at the end with any later ones attached as suppressed exceptions.

### Checks

- [x] Ensured tests pass, and added test coverage where needed.
- [x] Ensured the commit message follows the [Conventional Commits](https://www.conventionalcommits.org/) rules.
- [x] Considered the documentation impact, and opened a new documentation issue or doc-change PR if needed.